### PR TITLE
MacOS tweaks

### DIFF
--- a/import/CMakeLists.txt
+++ b/import/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(X11 REQUIRED)
 if(${X11_FOUND})
     if(TARGET_PLATFORM_MACOS)
         link_directories(/usr/X11/lib)
+        link_directories(/opt/X11/lib)
     endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,7 @@ endforeach()
 if(${X11_FOUND})
     if(TARGET_PLATFORM_MACOS)
         link_directories(/usr/X11/lib)
+        link_directories(/opt/X11/lib)
     endif()
 endif()
 

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -16,7 +16,7 @@
 #include "Util/algorithm.h"
 #include "Util/version.h"
 #include "nedit.h"
-#include "search.h"
+#include "Search.h"
 #include "userCmds.h"
 
 #include <yaml-cpp/yaml.h>


### PR DESCRIPTION
These changes make it possible to build on MacOS Mojave (they moved the X11 libraries to `/opt/X11`), and fix a build warning.

I do still get these warnings at build-time:
```
[ 71%] Building CXX object src/CMakeFiles/nedit-ng.dir/DocumentWidget.cpp.o
/Users/anj/Software/other/nedit-ng/src/DocumentWidget.cpp:7084:109: warning: 
      format specifies type 'long' but the argument has type 'int64_t'
      (aka 'long long') [-Wformat]
  ...%8li %s", i + 1, qPrintable(fi.pathname), qPrintable(fi.filename), Tags::tagPosInf[i]...
     ~~~~                                                               ^~~~~~~~~~~~~~~~~~
     %8lli
/Users/anj/Software/other/nedit-ng/src/DocumentWidget.cpp:7090:106: warning: 
      format specifies type 'long' but the argument has type 'int64_t'
      (aka 'long long') [-Wformat]
  ...%8li", i + 1, qPrintable(fi.pathname), qPrintable(fi.filename), Tags::tagPosInf[i]);
     ~~~~                                                            ^~~~~~~~~~~~~~~~~~
     %8lli
2 warnings generated.
```
which you might be able to fix should you wish to, and this one:
```
[ 99%] Building CXX object import/CMakeFiles/nedit-import.dir/import.cpp.o
In file included from /Users/anj/Software/other/nedit-ng/import/import.cpp:386:
In file included from /usr/X11R6/include/X11/Xresource.h:53:
In file included from /usr/X11R6/include/X11/Xlib.h:47:
/usr/X11R6/include/X11/Xfuncproto.h:174:24: warning: named variadic macros are a
      GNU extension [-Wvariadic-macros]
#define _X_NONNULL(args...)  __attribute__((nonnull(args)))
                       ^
1 warning generated.
```
which you won't.

Not relevant to this PR but... I have nedit-ng (built and) working on MacOS Mojave, but the version built on the previous OS High Sierra (with a slightly older version of clang) dies there with an abort. In both cases I'm building against Qt 5.14.1. When I run it under lldb I get this backtrace:
```
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
  * frame #0: 0x00007fff6d956b66 libsystem_kernel.dylib`__pthread_kill + 10
    frame #1: 0x00007fff6db21080 libsystem_pthread.dylib`pthread_kill + 333
    frame #2: 0x00007fff6d8b21ae libsystem_c.dylib`abort + 127
    frame #3: 0x00000001012eee39 QtCore`___lldb_unnamed_symbol173$$QtCore + 9
    frame #4: 0x00000001012f0584 QtCore`QMessageLogger::fatal(char const*, ...) const + 202
    frame #5: 0x0000000100148e7c nedit-ng`loadResource(resource=<unavailable>) at Resource.cpp:19 [opt]
    frame #6: 0x00000001001446ef nedit-ng`(anonymous namespace)::loadMenuItemString(QString const&, std::__1::vector<MenuData, std::__1::allocator<MenuData> >&, CommandTypes) [inlined] (anonymous namespace)::loadShellMenuYaml(menuItems=size=0) at userCmds.cpp:465 [opt]
    frame #7: 0x00000001001446b0 nedit-ng`(anonymous namespace)::loadMenuItemString(inString=<unavailable>, menuItems=size=0, listType=Shell) at userCmds.cpp:602 [opt]
    frame #8: 0x00000001000cb98a nedit-ng`Preferences::(anonymous namespace)::translatePrefFormats(fileVer=0) at Preferences.cpp:383 [opt]
    frame #9: 0x000000010008d8ce nedit-ng`Main::Main(this=0x00007ffeefbffa30, args=0x00007ffeefbffa40) at Main.cpp:95 [opt]
    frame #10: 0x000000010013c155 nedit-ng`main(argc=<unavailable>, argv=0x00007ffeefbffa90) at nedit.cpp:130 [opt]
    frame #11: 0x00007fff6d806015 libdyld.dylib`start + 1
```
If you can suggest a fix I'd be happy to try it.