### PR TITLE
Keep user interface alive during long operations

### DIFF
--- a/src/DocumentWidget.cpp
+++ b/src/DocumentWidget.cpp
@@ -3290,6 +3290,7 @@ void DocumentWidget::refreshWindowStates() {
 
 	Q_EMIT updateWindowReadOnly(this);
 	Q_EMIT updateWindowTitle(this);
+	Q_EMIT fontChanged(this);
 
 	// show/hide statsline as needed
 	if (modeMessageDisplayed() && !ui.statusFrame->isVisible()) {
@@ -4271,6 +4272,8 @@ void DocumentWidget::action_Set_Fonts(const QString &fontName) {
 	for (TextArea *area : textPanes()) {
 		area->setFont(font_);
 	}
+
+	Q_EMIT fontChanged(this);
 }
 
 /*

--- a/src/DocumentWidget.h
+++ b/src/DocumentWidget.h
@@ -83,6 +83,7 @@ Q_SIGNALS:
 	void updateStatus(DocumentWidget *document, TextArea *area);
 	void updateWindowReadOnly(DocumentWidget *document);
 	void updateWindowTitle(DocumentWidget *document);
+        void fontChanged(DocumentWidget *document);
 
 public:
 	void dragEndCallback(TextArea *area, const DragEndEvent *event);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -4797,6 +4797,8 @@ void MainWindow::allDocumentsBusy(const QString &message) {
 		modeMessageSet = true;
 	}
 
+	/* Keep UI alive while loading large files */
+	QApplication::processEvents(QEventLoop::ExcludeUserInputEvents | QEventLoop::ExcludeSocketNotifiers);
 	currentlyBusy = true;
 }
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1097,6 +1097,7 @@ DocumentWidget *MainWindow::createDocument(const QString &name) {
 	connect(document, &DocumentWidget::updateStatus, this, &MainWindow::updateStatus);
 	connect(document, &DocumentWidget::updateWindowReadOnly, this, &MainWindow::updateWindowReadOnly);
 	connect(document, &DocumentWidget::updateWindowTitle, this, &MainWindow::updateWindowTitle);
+	connect(document, &DocumentWidget::fontChanged, this, &MainWindow::updateWindowHints);
 
 	ui.tabWidget->addTab(document, name);
 	return document;
@@ -4749,6 +4750,7 @@ DocumentWidget *MainWindow::editNewFile(MainWindow *window, const QString &geome
 	window->updateWindowReadOnly(document);
 	window->updateStatus(document, document->firstPane());
 	window->updateWindowTitle(document);
+	window->updateWindowHints(document);
 	document->refreshTabState();
 
 	if (languageMode.isNull()) {
@@ -7281,6 +7283,17 @@ void MainWindow::updateStatus(DocumentWidget *document, TextArea *area) {
 	if (!document->modeMessageDisplayed()) {
 		document->ui.labelFileAndSize->setText(string);
 	}
+}
+
+/**
+ * @brief Update window geometry hints to allow for incremented resize.
+ * @param document
+ */
+void MainWindow::updateWindowHints(DocumentWidget *document)
+{
+	QFontMetrics fm(document->defaultFont());
+	QSize increment(fm.averageCharWidth(), fm.height());
+	setSizeIncrement(increment);
 }
 
 /*

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -412,6 +412,7 @@ public:
 
 private:
 	void focusChanged(QWidget *from, QWidget *to);
+	void updateWindowHints(DocumentWidget *);
 
 public Q_SLOTS:
 	void selectionChanged(bool selected);

--- a/src/Tags.cpp
+++ b/src/Tags.cpp
@@ -350,16 +350,16 @@ int loadTagsFile(const QString &tagSpec, int index, int recLevel) {
 
 	const PathInfo tagPathInfo = parseFilename(resolvedTagsFile);
 
-	/* This might take a while if you have a huge tags file (like I do)..
-	   keep the windows up to date and post a busy cursor so the user
-	   doesn't think we died. */
-	MainWindow::allDocumentsBusy(tr("Loading tags file..."));
-
 	QString filename;
 
 	QTextStream stream(&f);
 
 	while (!stream.atEnd()) {
+		/* This might take a while if you have a huge tags file (like I do)..
+		   keep the windows up to date and post a busy cursor so the user
+		   doesn't think we died. */
+		MainWindow::allDocumentsBusy(tr("Loading tags file..."));
+
 		QString line = stream.readLine();
 
 		/* the first character in the file decides if the file is treat as


### PR DESCRIPTION
- Redraw the window if needed when busy
- Call `allDocumentsBusy` repeatedly during long operations (as intended)
- This wouldn't be that hard to run in a separate thread