### PR TITLE
Ctags error

### DIFF
--- a/src/DocumentWidget.cpp
+++ b/src/DocumentWidget.cpp
@@ -7244,11 +7244,11 @@ void DocumentWidget::editTaggedLocation(TextArea *area, int i) {
 	   about 1/4 of the way down from the top */
 	const int64_t lineNum = documentToSearch->buffer()->BufCountLines(TextCursor(0), TextCursor(startPos));
 
-	int rows = area->getRows();
-
-	area->verticalScrollBar()->setValue(lineNum - (rows / 4));
-	area->horizontalScrollBar()->setValue(0);
-	area->TextSetCursorPos(TextCursor(endPos));
+	QPointer<TextArea> tagArea = MainWindow::fromDocument(documentToSearch)->lastFocus();
+	int rows = tagArea->getRows();
+	tagArea->verticalScrollBar()->setValue(lineNum - (rows / 4));
+	tagArea->horizontalScrollBar()->setValue(0);
+	tagArea->TextSetCursorPos(TextCursor(endPos));
 }
 
 /**

--- a/src/Tags.cpp
+++ b/src/Tags.cpp
@@ -174,7 +174,7 @@ bool delTag(int index) {
 */
 int scanCTagsLine(const QString &line, const QString &tagPath, int index) {
 
-	QRegExp regex(QLatin1String(R"(^([^\t]+)\t([^\t]+)\t([^\n]+)\n$)"));
+	QRegExp regex(QLatin1String(R"(^([^\t]+)\t([^\t]+)\t([^\n]+)$)"));
 	if (!regex.exactMatch(line)) {
 		return 0;
 	}

--- a/src/Tags.cpp
+++ b/src/Tags.cpp
@@ -874,7 +874,7 @@ bool addTagsFile(const QString &tagSpec, SearchMode mode) {
 		return false;
 	}
 
-	QStringList filenames = tagSpec.split(QLatin1Char(':'));
+	QStringList filenames = tagSpec.split(QDir::listSeparator());
 
 	for (const QString &filename : filenames) {
 
@@ -942,7 +942,7 @@ bool deleteTagsFile(const QString &tagSpec, SearchMode mode, bool force_unload) 
 
 	bool removed = true;
 
-	QStringList filenames = tagSpec.split(QLatin1Char(':'));
+	QStringList filenames = tagSpec.split(QDir::listSeparator());
 
 	for (const QString &filename : filenames) {
 


### PR DESCRIPTION
Hi Evan,

I found a few issues with the ctags handling when running on Windows, and make some attempts to address them:

1. loading and unloading not working due to the different path separator on Windows vs Unix
2. the regexp for searching ctags is having an extra '\n'
3. when a tag is found, nedit was scrolling the file where the action is invoked, instead of the file where the tag is defined

These are my first attempt to hack on nedit-ng, as well as Qt Creator and C++ (I have used PyQt on some of my projects), so if you see any issues or think of better fixes, feel free to discard them.

BTW, I only fixed the ctags handling, but I believe etags too have similar issues, though I am not familiar with etags enough to confirm/fix. Also, I think the tips files handling are having similar path issue, but once again, I don't know tips enough to work on them now.

Let me know if you have any questions/comments.

TK