### PR TITLE
support opening files by drag-and-drop from external file managers

### DIFF
--- a/src/DocumentWidget.cpp
+++ b/src/DocumentWidget.cpp
@@ -568,6 +568,7 @@ DocumentWidget::DocumentWidget(const QString &name, QWidget *parent, Qt::WindowF
 	// track what the last created document was so that focus_document("last")
 	// works correctly
 	LastCreated = this;
+	setAcceptDrops(true);
 
 	// Every document has a backing buffer
 	info_->buffer = std::make_shared<TextBuffer>();
@@ -7358,4 +7359,30 @@ WrapStyle DocumentWidget::wrapMode() const {
  */
 void DocumentWidget::setFileFormat(FileFormats fileFormat) {
 	info_->fileFormat = fileFormat;
+}
+
+/**
+ * @brief dragEnterEvent
+ * @param event
+ */
+void DocumentWidget::dragEnterEvent(QDragEnterEvent *event) {
+	if (event->mimeData()->hasUrls()) {
+		event->accept();
+	}
+}
+
+/**
+ * @brief dropEvent
+ * @param event
+ */
+void DocumentWidget::dropEvent(QDropEvent *event) {
+	auto urls = event->mimeData()->urls();
+	for (auto url : urls) {
+		if (url.isLocalFile()) {
+			QString fileName = url.toLocalFile();
+			open(fileName);
+		} else {
+			QApplication::beep();
+		}
+	}
 }

--- a/src/DocumentWidget.h
+++ b/src/DocumentWidget.h
@@ -293,6 +293,8 @@ private:
 	void updateMarkTable(TextCursor pos, int64_t nInserted, int64_t nDeleted);
 	void updateSelectionSensitiveMenu(QMenu *menu, const gsl::span<MenuData> &menuList, bool enabled);
 	void updateSelectionSensitiveMenus(bool enabled);
+	void dragEnterEvent(QDragEnterEvent *event) override;
+	void dropEvent(QDropEvent *event) override;
 
 public:
 	std::shared_ptr<DocumentInfo> info_;


### PR DESCRIPTION
Evan,

Here's the commit to support DnD files from Explorer into the nedit-ng to open. We get a beep if the dropped-in url is not a local file.

I have tested on Windows 10 and Linux Mint 19.3. Let me if you have any comments/questions. 

TK