### PR TITLE
extract version info from git for display on About dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,29 @@ add_definitions(-DQT_NO_CAST_FROM_ASCII)
 add_definitions(-DQT_NO_CAST_TO_ASCII)
 add_definitions(-DQT_NO_KEYWORDS)
 
+# extract nedit-ng version info if source directory is a git repo
+message(STATUS "Extracting nedit-ng version info with git...")
+find_package(Git)
+if(Git_FOUND)
+	execute_process(COMMAND ${GIT_EXECUTABLE} describe --dirty --always --tags
+					WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+					OUTPUT_VARIABLE GIT_OUTPUT
+					ERROR_VARIABLE GIT_ERROR)
+
+	if(GIT_OUTPUT)
+		string(STRIP ${GIT_OUTPUT} NEDIT_VERSION_GIT)
+		message(STATUS "#define NEDIT_VERSION_GIT \"${NEDIT_VERSION_GIT}\"")
+		add_definitions(-DNEDIT_VERSION_GIT=\"${NEDIT_VERSION_GIT}\")
+	elseif(GIT_ERROR)
+		string(STRIP ${GIT_ERROR} GIT_ERROR)
+		message(STATUS "Git error: ${GIT_ERROR}")
+	else()
+		message(STATUS "Unable to extract nedit-ng version info from git")
+	endif()
+else()
+	message(STATUS "Git is not installed")
+endif()
+
 add_subdirectory(Util)
 add_subdirectory(src)
 add_subdirectory(libs)

--- a/src/DialogAbout.cpp
+++ b/src/DialogAbout.cpp
@@ -33,7 +33,12 @@ DialogAbout::DialogAbout(QWidget *parent, Qt::WindowFlags f)
  */
 QString DialogAbout::createInfoString() {
 
+#ifdef NEDIT_VERSION_GIT
+	auto versionString   = tr(NEDIT_VERSION_GIT);
+#else
 	auto versionString   = tr("%1.%2").arg(NEDIT_VERSION_MAJ).arg(NEDIT_VERSION_REV);
+#endif
+
 	QString localeString = QLocale::system().bcp47Name();
 
 	return tr("nedit-ng version %1\n"


### PR DESCRIPTION
Evan,

Here's my hack to extract the version info from nedit-ng's git repo, so we can better track the version used to build the binaries. The approach seems to have been used in some of the projects out there.

These are the potential scenario:

1. source directory is cloned from nedit-ng repo (this is the best case) - version info will be captured with 'git describe' into the NEDIT_VERSION_GIT macro, then passed into the source via compiler switch

2. git is not installed, or source directory is not a git repo (a source tarball perhaps) - version info will fallback to NEDIT_VERSION_MAJ and NEDIT_VERSION_REV defined in version.h

Let me know if you have any comment/questions

TK