### PR TITLE
add new options to Text Fonts dialog on applying new fonts

### DIFF
--- a/src/DialogFonts.cpp
+++ b/src/DialogFonts.cpp
@@ -25,8 +25,6 @@ DialogFonts::DialogFonts(DocumentWidget *document, QWidget *parent, Qt::WindowFl
 		ui.buttonBox->removeButton(ui.buttonBox->button(QDialogButtonBox::Apply));
 		ui.buttonBox->removeButton(ui.buttonBox->button(QDialogButtonBox::Close));
 		ui.buttonBox->addButton(QDialogButtonBox::Cancel);
-		ui.fontSetAsDef->setChecked(true);
-		ui.fontSetAsDef->setEnabled(false);
 	}
 
 	const QFont font = document ? Font::fromString(document->fontName_) : Font::fromString(Preferences::GetPrefFontName());
@@ -79,7 +77,6 @@ void DialogFonts::updateFont() {
 	QString fontName = font.toString();
 
 	const bool applyToAll = ui.fontApplyAll->isChecked();
-	const bool setAsDef = ui.fontSetAsDef->isChecked();
 
 	if (applyToAll) {
 		for (DocumentWidget *doc : DocumentWidget::allDocuments()) {
@@ -87,9 +84,5 @@ void DialogFonts::updateFont() {
 		}
 	} else {
 		document_->action_Set_Fonts(fontName);
-	}
-
-	if (setAsDef) {
-		Preferences::SetPrefFont(fontName);
 	}
 }

--- a/src/DialogFonts.cpp
+++ b/src/DialogFonts.cpp
@@ -25,6 +25,8 @@ DialogFonts::DialogFonts(DocumentWidget *document, QWidget *parent, Qt::WindowFl
 		ui.buttonBox->removeButton(ui.buttonBox->button(QDialogButtonBox::Apply));
 		ui.buttonBox->removeButton(ui.buttonBox->button(QDialogButtonBox::Close));
 		ui.buttonBox->addButton(QDialogButtonBox::Cancel);
+		ui.fontSetAsDef->setChecked(true);
+		ui.fontSetAsDef->setEnabled(false);
 	}
 
 	const QFont font = document ? Font::fromString(document->fontName_) : Font::fromString(Preferences::GetPrefFontName());
@@ -76,9 +78,18 @@ void DialogFonts::updateFont() {
 	font.setPointSize(ui.fontSize->currentData().toInt());
 	QString fontName = font.toString();
 
-	if (document_) {
-		document_->action_Set_Fonts(fontName);
+	const bool applyToAll = ui.fontApplyAll->isChecked();
+	const bool setAsDef = ui.fontSetAsDef->isChecked();
+
+	if (applyToAll) {
+		for (DocumentWidget *doc : DocumentWidget::allDocuments()) {
+			doc->action_Set_Fonts(fontName);
+		}
 	} else {
+		document_->action_Set_Fonts(fontName);
+	}
+
+	if (setAsDef) {
 		Preferences::SetPrefFont(fontName);
 	}
 }

--- a/src/DialogFonts.ui
+++ b/src/DialogFonts.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>334</width>
-    <height>152</height>
+    <height>129</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -49,16 +49,6 @@
      </property>
      <property name="text">
       <string>Apply to all documents</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="fontSetAsDef">
-     <property name="focusPolicy">
-      <enum>Qt::StrongFocus</enum>
-     </property>
-     <property name="text">
-      <string>Set as default font</string>
      </property>
     </widget>
    </item>

--- a/src/DialogFonts.ui
+++ b/src/DialogFonts.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>334</width>
-    <height>129</height>
+    <height>152</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -40,6 +40,26 @@
        <widget class="QComboBox" name="fontSize"/>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="fontApplyAll">
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
+     <property name="text">
+      <string>Apply to all documents</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="fontSetAsDef">
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
+     <property name="text">
+      <string>Set as default font</string>
+     </property>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
Evan,

This is based on one of my older patches for nedit. It's something I find handy for myself as I usually open a lot of windows, especially when nedit's font setting dialog is rather clumsy. I feel it's still helpful for nedit-ng.

Two options added to the dialog:

1. apply to all open windows/documents
2. set as default text fonts (user still need to save the default settings)

Let me know what you think about it. Thanks.

![2020-12-12 13_51_48-MainWindow h - C__Users_teeka_OneDrive_Documents_projects_nedit-ng_src_](https://user-images.githubusercontent.com/494222/101976588-9a2cb100-3c81-11eb-8848-011604c9e1ce.jpg)
