### PR TITLE
reintroducing NEDIT_HOME environment variable support

### DIFF
--- a/Settings/Settings.cpp
+++ b/Settings/Settings.cpp
@@ -141,7 +141,7 @@ QFont font;
  * @return
  */
 QString configDirectory() {
-	static const QByteArray nedit_home = qgetenv("NEDIT_HOME");
+	static const QByteArray nedit_home = qgetenv("NEDIT_NG_HOME");
 	if (!nedit_home.isEmpty()) {
 		return QString::fromLocal8Bit(nedit_home);
 	}

--- a/Settings/Settings.cpp
+++ b/Settings/Settings.cpp
@@ -140,7 +140,7 @@ QFont font;
  * @return
  */
 QString configDirectory() {
-	QString nedit_home = qEnvironmentVariable("NEDIT_HOME");
+	static const QString nedit_home = qEnvironmentVariable("NEDIT_HOME");
 	if (!nedit_home.isEmpty()) {
 		return nedit_home;
 	}

--- a/Settings/Settings.cpp
+++ b/Settings/Settings.cpp
@@ -141,9 +141,9 @@ QFont font;
  * @return
  */
 QString configDirectory() {
-	static const QString nedit_home = qEnvironmentVariable("NEDIT_HOME");
+	static const QByteArray nedit_home = qgetenv("NEDIT_HOME");
 	if (!nedit_home.isEmpty()) {
-		return nedit_home;
+		return QString::fromLocal8Bit(nedit_home);
 	}
 
 	static const QString configDir = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation);

--- a/Settings/Settings.cpp
+++ b/Settings/Settings.cpp
@@ -5,6 +5,7 @@
 #include <QSettings>
 #include <QStandardPaths>
 #include <QtDebug>
+#include <QtGlobal>
 #include <random>
 
 namespace Settings {

--- a/Settings/Settings.cpp
+++ b/Settings/Settings.cpp
@@ -136,12 +136,27 @@ QStringList includePaths;
 QFont font;
 
 /**
+ * @brief configDirectory
+ * @return
+ */
+QString configDirectory() {
+	QString nedit_home = qEnvironmentVariable("NEDIT_HOME");
+	if (!nedit_home.isEmpty()) {
+		return nedit_home;
+	}
+
+	static const QString configDir = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation);
+	static const auto filename     = tr("%1/%2").arg(configDir, tr("nedit-ng"));
+	return filename;
+}
+
+/**
  * @brief themeFile
  * @return
  */
 QString themeFile() {
-	static const QString configDir = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation);
-	static const auto filename     = tr("%1/%2/%3").arg(configDir, tr("nedit-ng"), tr("theme.xml"));
+	static const QString configDir = configDirectory();
+	static const auto filename     = tr("%1/%2").arg(configDir, tr("theme.xml"));
 	return filename;
 }
 
@@ -150,8 +165,8 @@ QString themeFile() {
  * @return
  */
 QString configFile() {
-	static const QString configDir = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation);
-	static const auto filename     = tr("%1/%2/%3").arg(configDir, tr("nedit-ng"), tr("config.ini"));
+	static const QString configDir = configDirectory();
+	static const auto filename     = tr("%1/%2").arg(configDir, tr("config.ini"));
 	return filename;
 }
 
@@ -160,8 +175,8 @@ QString configFile() {
  * @return
  */
 QString historyFile() {
-	static const QString configDir = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation);
-	static const auto filename     = tr("%1/%2/%3").arg(configDir, tr("nedit-ng"), tr("history"));
+	static const QString configDir = configDirectory();
+	static const auto filename     = tr("%1/%2").arg(configDir, tr("history"));
 	return filename;
 }
 
@@ -170,8 +185,8 @@ QString historyFile() {
  * @return
  */
 QString autoLoadMacroFile() {
-	static const QString configDir = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation);
-	static const auto filename     = tr("%1/%2/%3").arg(configDir, tr("nedit-ng"), tr("autoload.nm"));
+	static const QString configDir = configDirectory();
+	static const auto filename     = tr("%1/%2").arg(configDir, tr("autoload.nm"));
 	return filename;
 }
 
@@ -180,8 +195,8 @@ QString autoLoadMacroFile() {
  * @return
  */
 QString languageModeFile() {
-	static const QString configDir = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation);
-	static const auto filename     = tr("%1/%2/%3").arg(configDir, tr("nedit-ng"), tr("languages.yaml"));
+	static const QString configDir = configDirectory();
+	static const auto filename     = tr("%1/%2").arg(configDir, tr("languages.yaml"));
 	return filename;
 }
 
@@ -190,8 +205,8 @@ QString languageModeFile() {
  * @return
  */
 QString macroMenuFile() {
-	static const QString configDir = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation);
-	static const auto filename     = tr("%1/%2/%3").arg(configDir, tr("nedit-ng"), tr("macros.yaml"));
+	static const QString configDir = configDirectory();
+	static const auto filename     = tr("%1/%2").arg(configDir, tr("macros.yaml"));
 	return filename;
 }
 
@@ -200,8 +215,8 @@ QString macroMenuFile() {
  * @return
  */
 QString shellMenuFile() {
-	static const QString configDir = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation);
-	static const auto filename     = tr("%1/%2/%3").arg(configDir, tr("nedit-ng"), tr("shell.yaml"));
+	static const QString configDir = configDirectory();
+	static const auto filename     = tr("%1/%2").arg(configDir, tr("shell.yaml"));
 	return filename;
 }
 
@@ -210,8 +225,8 @@ QString shellMenuFile() {
  * @return
  */
 QString contextMenuFile() {
-	static const QString configDir = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation);
-	static const auto filename     = tr("%1/%2/%3").arg(configDir, tr("nedit-ng"), tr("context.yaml"));
+	static const QString configDir = configDirectory();
+	static const auto filename     = tr("%1/%2").arg(configDir, tr("context.yaml"));
 	return filename;
 }
 
@@ -220,8 +235,8 @@ QString contextMenuFile() {
  * @return
  */
 QString styleFile() {
-	static const QString configDir = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation);
-	static const auto filename     = tr("%1/%2/%3").arg(configDir, tr("nedit-ng"), tr("style.qss"));
+	static const QString configDir = configDirectory();
+	static const auto filename     = tr("%1/%2").arg(configDir, tr("style.qss"));
 	return filename;
 }
 
@@ -230,8 +245,8 @@ QString styleFile() {
  * @return
  */
 QString highlightPatternsFile() {
-	static const QString configDir = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation);
-	static const auto filename     = tr("%1/%2/%3").arg(configDir, tr("nedit-ng"), tr("patterns.yaml"));
+	static const QString configDir = configDirectory();
+	static const auto filename     = tr("%1/%2").arg(configDir, tr("patterns.yaml"));
 	return filename;
 }
 
@@ -240,8 +255,8 @@ QString highlightPatternsFile() {
  * @return
  */
 QString smartIndentFile() {
-	static const QString configDir = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation);
-	static const auto filename     = tr("%1/%2/%3").arg(configDir, tr("nedit-ng"), tr("indent.yaml"));
+	static const QString configDir = configDirectory();
+	static const auto filename     = tr("%1/%2").arg(configDir, tr("indent.yaml"));
 	return filename;
 }
 


### PR DESCRIPTION
reintroducing NEDIT_HOME environment variable support, if you want to override where nedit loads/stores its configuration from, this will allow you to specify the directory