### PR TITLE
Implements opening from clipboard as discussed in issue #205

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2110,11 +2110,9 @@ void MainWindow::action_Shift_Open_Selected(DocumentWidget *document) {
 	QString copied;
 
 	// Get the clipboard text, if there's nothing copied, do nothing
-	if (QApplication::clipboard()->supportsSelection()) {
-		const QMimeData *mimeData = QApplication::clipboard()->mimeData(QClipboard::Clipboard);
-		if (mimeData->hasText()) {
-			copied = mimeData->text();
-		}
+	const QMimeData *mimeData = QApplication::clipboard()->mimeData(QClipboard::Clipboard);
+	if (mimeData->hasText()) {
+		copied = mimeData->text();
 	}
 
 	if (!copied.isEmpty()) {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -707,6 +707,7 @@ void MainWindow::setupMenuStrings() {
 	create_shortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_I), this, [this]() { action_Shift_Find_Incremental(); });
 	create_shortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_R), this, [this]() { action_Shift_Replace(); });
 	create_shortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_M), this, [this]() { action_Shift_Goto_Matching(); });
+	create_shortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_Y), this, [this]() { action_Shift_Open_Selected(); });
 
 	// This is an annoying solution... we can probably do better...
 	for (int key = Qt::Key_A; key <= Qt::Key_Z; ++key) {
@@ -2087,6 +2088,42 @@ void MainWindow::action_Open_Selected_triggered() {
 	if (DocumentWidget *document = currentDocument()) {
 		action_Open_Selected(document);
 	}
+}
+
+/**
+ * @brief MainWindow::action_Shift_Open_Selected
+ */
+void MainWindow::action_Shift_Open_Selected() {
+	if (DocumentWidget *document = currentDocument()) {
+		action_Shift_Open_Selected(document);
+	}
+}
+
+/**
+ * @brief MainWindow::action_Shift_Open_Selected
+ * @param document
+ */
+void MainWindow::action_Shift_Open_Selected(DocumentWidget *document) {
+
+	emit_event("open_copied");
+
+	QString copied;
+
+	// Get the clipboard text, if there's nothing copied, do nothing
+	if (QApplication::clipboard()->supportsSelection()) {
+		const QMimeData *mimeData = QApplication::clipboard()->mimeData(QClipboard::Clipboard);
+		if (mimeData->hasText()) {
+			copied = mimeData->text();
+		}
+	}
+
+	if (!copied.isEmpty()) {
+		openFile(document, copied);
+	} else {
+		QApplication::beep();
+	}
+
+	MainWindow::checkCloseEnableState();
 }
 
 QFileInfoList MainWindow::openFileHelperSystem(DocumentWidget *document, const QRegularExpressionMatch &match, QString *searchPath, QString *searchName) const {

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -240,6 +240,7 @@ public:
 	void action_Unload_Tags_File(DocumentWidget *document, const QString &filename);
 	void action_Unload_Tips_File(DocumentWidget *document, const QString &filename);
 	void action_Upper_case(DocumentWidget *document);
+	void action_Shift_Open_Selected(DocumentWidget *document);
 
 	// has no visual shortcut at all
 	void action_Next_Document();
@@ -263,6 +264,7 @@ public:
 	void action_Shift_Right_Tabs();
 	void action_Shift_Find_Selection();
 	void action_Shift_Find_Incremental();
+	void action_Shift_Open_Selected();
 
 public:
 	// groups

--- a/src/macro.cpp
+++ b/src/macro.cpp
@@ -4525,6 +4525,7 @@ const SubRoutine MenuMacroSubrNames[] = {
 	{"open", menuEventSU<&MainWindow::action_Open>},
 	{"open_dialog", menuEventU<&MainWindow::action_Open>},
 	{"open_selected", menuEventU<&MainWindow::action_Open_Selected>},
+	{"open_copied", menuEventU<&MainWindow::action_Shift_Open_Selected>},
 	{"close", closeMS},
 	{"save", menuEventU<&MainWindow::action_Save>},
 	{"save_as", saveAsMS},


### PR DESCRIPTION
`Ctrl+Shift+Y` Now will open what is in the copy buffer of the clipboard, which works well for platforms that don't support cross-application selection primary selection buffers.