### PR TITLE
Fixes reload when changing tab issue (#112)!

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -52,7 +52,6 @@
 #include <QMimeData>
 #include <QShortcut>
 #include <QToolTip>
-#include <QTimer>
 #include <qplatformdefs.h>
 
 #include <cmath>
@@ -258,6 +257,12 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
 	for (MainWindow *window : windows) {
 		window->ui.action_Move_Tab_To->setEnabled(enabled);
 	}
+
+	connect(
+		this, &MainWindow::checkForChangesToFile, this, [](DocumentWidget *document) {
+			document->checkForChangesToFile();
+		},
+		Qt::QueuedConnection);
 }
 
 /**
@@ -4788,7 +4793,6 @@ DocumentWidget *MainWindow::editNewFile(MainWindow *window, const QString &geome
 		document->raiseDocumentWindow();
 	}
 
-
 	return document;
 }
 
@@ -5446,9 +5450,7 @@ void MainWindow::focusChanged(QWidget *from, QWidget *to) {
 			endISearch();
 
 			// Check for changes to read-only status and/or file modifications
-			QTimer::singleShot(0, [document]() {
-				document->checkForChangesToFile();
-			});
+			Q_EMIT checkForChangesToFile(document);
 		}
 	}
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -52,6 +52,7 @@
 #include <QMimeData>
 #include <QShortcut>
 #include <QToolTip>
+#include <QTimer>
 #include <qplatformdefs.h>
 
 #include <cmath>
@@ -5445,7 +5446,9 @@ void MainWindow::focusChanged(QWidget *from, QWidget *to) {
 			endISearch();
 
 			// Check for changes to read-only status and/or file modifications
-			document->checkForChangesToFile();
+			QTimer::singleShot(0, [document]() {
+				document->checkForChangesToFile();
+			});
 		}
 	}
 }

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -415,6 +415,9 @@ private:
 	void focusChanged(QWidget *from, QWidget *to);
 	void updateWindowHints(DocumentWidget *);
 
+Q_SIGNALS:
+	void checkForChangesToFile(DocumentWidget *document);
+
 public Q_SLOTS:
 	void selectionChanged(bool selected);
 	void undoAvailable(bool available);


### PR DESCRIPTION
So the problem was that by checking for file changes in the focus event itself, we are popping up
the messagebox BEFORE the focus event is complete. And the update caused by the focus event happens
AFTER it is complete.

So the solution is to NOT check for changes inside the focus event, but instead to schedule
a check for the immediate future. (Done via a single shot timer with a 0 timeout). Inspired
by kernel "bottom half interrupt handlers".

This allows the windowing system to complete processes of existing events, including the repaint
and then will immediately check for changes.

Woot!