### PR TITLE
Moar QStringLiteral! (replaces unnecessary tr usage with QStringLiteral where it's just used for concatenation)

### DIFF
--- a/Settings/Settings.cpp
+++ b/Settings/Settings.cpp
@@ -147,7 +147,7 @@ QString configDirectory() {
 	}
 
 	static const QString configDir = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation);
-	static const auto filename     = tr("%1/%2").arg(configDir, tr("nedit-ng"));
+	static const auto filename     = QStringLiteral("%1/nedit-ng").arg(configDir);
 	return filename;
 }
 
@@ -157,7 +157,7 @@ QString configDirectory() {
  */
 QString themeFile() {
 	static const QString configDir = configDirectory();
-	static const auto filename     = tr("%1/%2").arg(configDir, tr("theme.xml"));
+	static const auto filename     = QStringLiteral("%1/theme.xml").arg(configDir);
 	return filename;
 }
 
@@ -167,7 +167,7 @@ QString themeFile() {
  */
 QString configFile() {
 	static const QString configDir = configDirectory();
-	static const auto filename     = tr("%1/%2").arg(configDir, tr("config.ini"));
+	static const auto filename     = QStringLiteral("%1/config.ini").arg(configDir);
 	return filename;
 }
 
@@ -177,7 +177,7 @@ QString configFile() {
  */
 QString historyFile() {
 	static const QString configDir = configDirectory();
-	static const auto filename     = tr("%1/%2").arg(configDir, tr("history"));
+	static const auto filename     = QStringLiteral("%1/history").arg(configDir);
 	return filename;
 }
 
@@ -187,7 +187,7 @@ QString historyFile() {
  */
 QString autoLoadMacroFile() {
 	static const QString configDir = configDirectory();
-	static const auto filename     = tr("%1/%2").arg(configDir, tr("autoload.nm"));
+	static const auto filename     = QStringLiteral("%1/autoload.nm").arg(configDir);
 	return filename;
 }
 
@@ -197,7 +197,7 @@ QString autoLoadMacroFile() {
  */
 QString languageModeFile() {
 	static const QString configDir = configDirectory();
-	static const auto filename     = tr("%1/%2").arg(configDir, tr("languages.yaml"));
+	static const auto filename     = QStringLiteral("%1/languages.yaml").arg(configDir);
 	return filename;
 }
 
@@ -207,7 +207,7 @@ QString languageModeFile() {
  */
 QString macroMenuFile() {
 	static const QString configDir = configDirectory();
-	static const auto filename     = tr("%1/%2").arg(configDir, tr("macros.yaml"));
+	static const auto filename     = QStringLiteral("%1/macros.yaml").arg(configDir);
 	return filename;
 }
 
@@ -217,7 +217,7 @@ QString macroMenuFile() {
  */
 QString shellMenuFile() {
 	static const QString configDir = configDirectory();
-	static const auto filename     = tr("%1/%2").arg(configDir, tr("shell.yaml"));
+	static const auto filename     = QStringLiteral("%1/shell.yaml").arg(configDir);
 	return filename;
 }
 
@@ -227,7 +227,7 @@ QString shellMenuFile() {
  */
 QString contextMenuFile() {
 	static const QString configDir = configDirectory();
-	static const auto filename     = tr("%1/%2").arg(configDir, tr("context.yaml"));
+	static const auto filename     = QStringLiteral("%1/context.yaml").arg(configDir);
 	return filename;
 }
 
@@ -237,7 +237,7 @@ QString contextMenuFile() {
  */
 QString styleFile() {
 	static const QString configDir = configDirectory();
-	static const auto filename     = tr("%1/%2").arg(configDir, tr("style.qss"));
+	static const auto filename     = QStringLiteral("%1/style.qss").arg(configDir);
 	return filename;
 }
 
@@ -247,7 +247,7 @@ QString styleFile() {
  */
 QString highlightPatternsFile() {
 	static const QString configDir = configDirectory();
-	static const auto filename     = tr("%1/%2").arg(configDir, tr("patterns.yaml"));
+	static const auto filename     = QStringLiteral("%1/patterns.yaml").arg(configDir);
 	return filename;
 }
 
@@ -257,7 +257,7 @@ QString highlightPatternsFile() {
  */
 QString smartIndentFile() {
 	static const QString configDir = configDirectory();
-	static const auto filename     = tr("%1/%2").arg(configDir, tr("indent.yaml"));
+	static const auto filename     = QStringLiteral("%1/indent.yaml").arg(configDir);
 	return filename;
 }
 

--- a/src/CommandRecorder.cpp
+++ b/src/CommandRecorder.cpp
@@ -95,7 +95,7 @@ QString actionToString(const Event *ev) {
  * @return
  */
 QString CommandRecorder::quoteString(const QString &s) {
-	return tr("\"%1\"").arg(s);
+	return QStringLiteral("\"%1\"").arg(s);
 }
 
 /**

--- a/src/DialogDrawingStyles.cpp
+++ b/src/DialogDrawingStyles.cpp
@@ -452,7 +452,7 @@ void DialogDrawingStyles::chooseColor(QLineEdit *edit) {
 
 	QColor color = QColorDialog::getColor(X11Colors::fromString(name), this);
 	if (color.isValid()) {
-		edit->setText(tr("#%1").arg((color.rgb() & 0x00ffffff), 6, 16, QLatin1Char('0')));
+		edit->setText(QStringLiteral("#%1").arg((color.rgb() & 0x00ffffff), 6, 16, QLatin1Char('0')));
 	}
 }
 

--- a/src/DialogFonts.cpp
+++ b/src/DialogFonts.cpp
@@ -30,7 +30,7 @@ DialogFonts::DialogFonts(DocumentWidget *document, QWidget *parent, Qt::WindowFl
 	const QFont font = document ? Font::fromString(document->fontName_) : Font::fromString(Preferences::GetPrefFontName());
 
 	for (int size : QFontDatabase::standardSizes()) {
-		ui.fontSize->addItem(tr("%1").arg(size), size);
+		ui.fontSize->addItem(QStringLiteral("%1").arg(size), size);
 	}
 
 	ui.fontCombo->setCurrentFont(font);

--- a/src/DialogLanguageModes.cpp
+++ b/src/DialogLanguageModes.cpp
@@ -374,7 +374,7 @@ bool DialogLanguageModes::updateLanguageList(Verbosity verbosity) {
 					int colon  = oldLM->name.indexOf(QLatin1Char(':'));
 					int oldLen = (colon == -1) ? oldLM->name.size() : colon;
 
-					auto tempName = tr("%1:%2").arg(oldLM->name.left(oldLen), newLM->name);
+					auto tempName = QStringLiteral("%1:%2").arg(oldLM->name.left(oldLen), newLM->name);
 					newLM->name   = tempName;
 				}
 			}

--- a/src/DocumentWidget.cpp
+++ b/src/DocumentWidget.cpp
@@ -469,7 +469,7 @@ DocumentWidget *DocumentWidget::editExistingFile(DocumentWidget *inDocument, con
 	Q_EMIT document->updateStatus(document, nullptr);
 
 	// Add the name to the convenience menu of previously opened files
-	auto fullname = tr("%1%2").arg(path, name);
+	auto fullname = QStringLiteral("%1%2").arg(path, name);
 
 	if (Preferences::GetPrefAlwaysCheckRelTagsSpecs()) {
 		Tags::addRelTagsFile(Preferences::GetPrefTagFile(), path, Tags::SearchMode::TAG);
@@ -759,9 +759,9 @@ void DocumentWidget::refreshTabState() {
 		if (absTruncate > 3) {
 			if (filename.size() > absTruncate) {
 				if (Settings::truncateLongNamesInTabs > 0) {
-					filename = tr("%1%2").arg(QLatin1String("..."), filename.right(absTruncate - 3));
+					filename = QStringLiteral("%1%2").arg(QLatin1String("..."), filename.right(absTruncate - 3));
 				} else {
-					filename = tr("%1%2").arg(filename.left(absTruncate - 3), QLatin1String("..."));
+					filename = QStringLiteral("%1%2").arg(filename.left(absTruncate - 3), QLatin1String("..."));
 				}
 			}
 		} else {
@@ -780,9 +780,9 @@ void DocumentWidget::refreshTabState() {
 		const int alignment = style->styleHint(QStyle::SH_TabBar_Alignment);
 
 		if (alignment != Qt::AlignRight) {
-			labelString = tr("%1%2").arg(info_->fileChanged ? tr("*") : QString(), filename);
+			labelString = QStringLiteral("%1%2").arg(info_->fileChanged ? tr("*") : QString(), filename);
 		} else {
-			labelString = tr("%2%1").arg(info_->fileChanged ? tr("*") : QString(), filename);
+			labelString = QStringLiteral("%2%1").arg(info_->fileChanged ? tr("*") : QString(), filename);
 		}
 	}
 
@@ -1942,9 +1942,9 @@ void DocumentWidget::removeBackupFile() const {
 QString DocumentWidget::backupFileName() const {
 
 	if (info_->filenameSet) {
-		return tr("%1~%2").arg(info_->path, info_->filename);
+		return QStringLiteral("%1~%2").arg(info_->path, info_->filename);
 	} else {
-		return PrependHome(tr("~%1").arg(info_->filename));
+		return PrependHome(QStringLiteral("~%1").arg(info_->filename));
 	}
 }
 
@@ -2134,7 +2134,7 @@ QString DocumentWidget::fullPath() const {
 	}
 
 	Q_ASSERT(info_->path.endsWith(QLatin1Char('/')));
-	return tr("%1%2").arg(info_->path, info_->filename);
+	return QStringLiteral("%1%2").arg(info_->path, info_->filename);
 }
 
 /**
@@ -2732,7 +2732,7 @@ bool DocumentWidget::writeBckVersion() {
 		QString fullname = fullPath();
 
 		// Generate name for old version
-		auto bckname = tr("%1.bck").arg(fullname);
+		auto bckname = QStringLiteral("%1.bck").arg(fullname);
 
 		// Delete the old backup file
 		// Errors are ignored; we'll notice them later.
@@ -7046,7 +7046,7 @@ int DocumentWidget::findAllMatches(TextArea *area, const QString &string) {
 		if (QFileInfo(fileToSearch).isAbsolute()) {
 			Tags::tagFiles[nMatches] = fileToSearch;
 		} else {
-			Tags::tagFiles[nMatches] = tr("%1%2").arg(tagPath, fileToSearch);
+			Tags::tagFiles[nMatches] = QStringLiteral("%1%2").arg(tagPath, fileToSearch);
 		}
 
 		Tags::tagSearch[nMatches] = searchString;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1714,7 +1714,7 @@ DocumentWidget *MainWindow::findWindowWithFile(const QString &filename, const QS
 #ifdef Q_OS_UNIX
 	if (!Preferences::GetPrefHonorSymlinks()) {
 
-		QString fullname = tr("%1%2").arg(path, filename);
+		auto fullname = QStringLiteral("%1%2").arg(path, filename);
 
 		QT_STATBUF attribute;
 		if (QT_STAT(fullname.toUtf8().data(), &attribute) == 0) {
@@ -2137,7 +2137,7 @@ QFileInfoList MainWindow::openFileHelperSystem(DocumentWidget *document, const Q
 	for (const QString &includeDir : includeDirs) {
 		// we need to do this because someone could write #include <path/to/file.h>
 		// which confuses QDir..
-		QFileInfo fullPath = tr("%1/%2").arg(includeDir, match.captured(1));
+		QFileInfo fullPath = QStringLiteral("%1/%2").arg(includeDir, match.captured(1));
 		QString filename   = fullPath.fileName();
 		QString filepath   = fullPath.path();
 
@@ -2185,7 +2185,7 @@ QFileInfoList MainWindow::openFileHelperString(DocumentWidget *document, const Q
 	} else {
 		// we need to do this because someone could write #include "path/to/file.h"
 		// which confuses QDir..
-		QFileInfo fullPath = tr("%1/%2").arg(document->path(), text);
+		QFileInfo fullPath = QStringLiteral("%1/%2").arg(document->path(), text);
 		QString filename   = fullPath.fileName();
 		QString filepath   = fullPath.path();
 


### PR DESCRIPTION
in the past I've used `tr` as a shorthand for "make a QString that I want to later use .arg() with"

but frankly this is a bit of a misuse and only makes more work for translators for things such as
simple concatenation like: `tr("%1%2")` or similar.

So, now that I've learned about `QStringLiteral` AND the fact that it is more efficient in many cases
that constructing a normal `QString`... using this where reasonable!