### PR TITLE
Sync scrollbar on new pane creation

### DIFF
--- a/src/DocumentWidget.cpp
+++ b/src/DocumentWidget.cpp
@@ -4019,6 +4019,7 @@ void DocumentWidget::splitPane() {
 		area->setLineNumCols(activeArea->getLineNumCols());
 		area->setBacklightCharTypes(backlightCharTypes_);
 		area->setFont(font_);
+		area->verticalScrollBar()->setValue(activeArea->verticalScrollBar()->value());
 	}
 
 	attachHighlightToWidget(area);


### PR DESCRIPTION
Make new panes start with their vertical scroll set to match the original scroll

Fixes issue #239