### PR TITLE
Refactored fixed with font to be more robust (#234)

### DIFF
--- a/src/CallTipWidget.cpp
+++ b/src/CallTipWidget.cpp
@@ -14,8 +14,6 @@ CallTipWidget::CallTipWidget(QWidget *parent, Qt::WindowFlags f)
 
 	ui.setupUi(this);
 
-	ui.labelTip->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-
 	setAttribute(Qt::WA_DeleteOnClose, true);
 	ui.labelTip->setPalette(QToolTip::palette());
 

--- a/src/DialogAbout.cpp
+++ b/src/DialogAbout.cpp
@@ -15,11 +15,6 @@ DialogAbout::DialogAbout(QWidget *parent, Qt::WindowFlags f)
 
 	ui.setupUi(this);
 
-	ui.textAbout->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-	ui.textThanks->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-	ui.textTranslations->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-	ui.textLicense->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-
 	ui.textAbout->setText(tr("%1"
 							 "\n"
 							 "nedit-ng was written by Evan Teran. It is intended to be a modern replacement for the Nirvana Editor (aka NEdit). The author has been using NEdit as his primary code editor for many years, and while it continues to be a superior editor in many ways, it is unfortunately showing its age. So nedit-ng was born out of a desire to have an editor that functions as close to the original as possible, but utilizing a modern toolkit (Qt). This will allow nedit-ng to enjoy the benefit of modern features such as:\n"

--- a/src/DialogDuplicateTags.cpp
+++ b/src/DialogDuplicateTags.cpp
@@ -15,8 +15,6 @@ DialogDuplicateTags::DialogDuplicateTags(DocumentWidget *document, TextArea *are
 
 	ui.setupUi(this);
 	connectSlots();
-
-	ui.listWidget->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
 }
 
 /**

--- a/src/DialogLanguageModes.cpp
+++ b/src/DialogLanguageModes.cpp
@@ -29,8 +29,6 @@ DialogLanguageModes::DialogLanguageModes(DialogSyntaxPatterns *dialogSyntaxPatte
 	ui.setupUi(this);
 	connectSlots();
 
-	ui.editDelimiters->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-
 	CommonDialog::setButtonIcons(&ui);
 
 	model_ = new LanguageModeModel(this);

--- a/src/DialogMacros.cpp
+++ b/src/DialogMacros.cpp
@@ -24,8 +24,6 @@ DialogMacros::DialogMacros(QWidget *parent, Qt::WindowFlags f)
 	ui.setupUi(this);
 	connectSlots();
 
-	ui.editMacro->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-
 	CommonDialog::setButtonIcons(&ui);
 
 	ui.editAccelerator->setMaximumSequenceLength(1);

--- a/src/DialogOutput.cpp
+++ b/src/DialogOutput.cpp
@@ -10,8 +10,6 @@ DialogOutput::DialogOutput(QWidget *parent, Qt::WindowFlags f)
 	: Dialog(parent, f) {
 
 	ui.setupUi(this);
-
-	ui.plainTextEdit->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
 }
 
 /**

--- a/src/DialogShellMenu.cpp
+++ b/src/DialogShellMenu.cpp
@@ -21,8 +21,6 @@ DialogShellMenu::DialogShellMenu(QWidget *parent, Qt::WindowFlags f)
 	ui.setupUi(this);
 	connectSlots();
 
-	ui.editCommand->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-
 	CommonDialog::setButtonIcons(&ui);
 
 	ui.editAccelerator->setMaximumSequenceLength(1);

--- a/src/DialogSmartIndent.cpp
+++ b/src/DialogSmartIndent.cpp
@@ -28,10 +28,6 @@ DialogSmartIndent::DialogSmartIndent(DocumentWidget *document, QWidget *parent, 
 	ui.setupUi(this);
 	connectSlots();
 
-	ui.editInit->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-	ui.editNewline->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-	ui.editModMacro->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-
 	QString languageMode = Preferences::LanguageModeName((document->getLanguageMode() == PLAIN_LANGUAGE_MODE) ? 0 : document->getLanguageMode());
 
 	updateLanguageModes();

--- a/src/DialogSmartIndentCommon.cpp
+++ b/src/DialogSmartIndentCommon.cpp
@@ -20,7 +20,6 @@ DialogSmartIndentCommon::DialogSmartIndentCommon(QWidget *parent, Qt::WindowFlag
 	ui.setupUi(this);
 	connectSlots();
 
-	ui.editCode->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
 	ui.editCode->setPlainText(SmartIndent::CommonMacros);
 }
 

--- a/src/DialogSyntaxPatterns.cpp
+++ b/src/DialogSyntaxPatterns.cpp
@@ -30,10 +30,6 @@ DialogSyntaxPatterns::DialogSyntaxPatterns(MainWindow *window, Qt::WindowFlags f
 	ui.setupUi(this);
 	connectSlots();
 
-	ui.editRegex->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-	ui.editRegexEnd->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-	ui.editRegexError->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-
 	CommonDialog::setButtonIcons(&ui);
 
 	model_ = new HighlightPatternModel(this);

--- a/src/DialogWindowBackgroundMenu.cpp
+++ b/src/DialogWindowBackgroundMenu.cpp
@@ -24,8 +24,6 @@ DialogWindowBackgroundMenu::DialogWindowBackgroundMenu(QWidget *parent, Qt::Wind
 	ui.setupUi(this);
 	connectSlots();
 
-	ui.editMacro->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-
 	CommonDialog::setButtonIcons(&ui);
 
 	ui.editAccelerator->setMaximumSequenceLength(1);

--- a/src/nedit.cpp
+++ b/src/nedit.cpp
@@ -130,6 +130,19 @@ int main(int argc, char *argv[]) {
 		QIcon::setThemeName(QLatin1String("breeze-dark-nedit"));
 	}
 
+	// Make all text fields use fixed-width fonts by default
+	QFont fixedFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+	QApplication::setFont(fixedFont, "QLineEdit");
+	QApplication::setFont(fixedFont, "QTextEdit");
+	QApplication::setFont(fixedFont, "QPlainTextEdit");
+
+	// NEdit classic applied fixed-width fonts to list widgets, but since
+	// they're not editable, it's not really needed here. I imagine it
+	// was there to deal with fake columns in the tags conflict dialog,
+	// or anywhere else that used spaces to emulate columns. Motif didn't
+	// have column-based list widgets.
+	// QApplication::setFont(fixedFont, "QListWidget");
+
 	Main main{arguments};
 
 	// Process events.


### PR DESCRIPTION
NEdit classic applied fixed-width fonts as a design decision to all
text-entry fields. This was done with a VendorShell resource which
categorized fonts into button fonts, label fonts, text fonts, etc.
Here we use QWidget class-based defaults which is the closest thing.