### PR TITLE
Fixes issue #260 (Hopefully) by making sure that the selection events are fired.

### DIFF
--- a/src/CommonDialog.h
+++ b/src/CommonDialog.h
@@ -93,8 +93,16 @@ template <class Ui, class Model>
 void deleteItem(Ui *ui, Model *model, QModelIndex *deleted) {
 	QModelIndex index = ui->listItems->currentIndex();
 	if (index.isValid()) {
+
+		const int deletedRow = index.row();
+
 		*deleted = index;
 		model->deleteItem(index);
+
+		ui->listItems->setCurrentIndex(QModelIndex());
+
+		QModelIndex newIndex = model->index(deletedRow, 0);
+		ui->listItems->setCurrentIndex(newIndex);
 	}
 
 	ui->listItems->scrollTo(ui->listItems->currentIndex());


### PR DESCRIPTION
 Fixes issue #260 (Hopefully). So the issue seems to be a matter of making sure that Qt received the "selection" changed event
 When deleting an item, the index of the selection doesn't really change (delete item ar index 3, and that item goes away, but
 the selection remains at index 3). So, I've added some code to first invalidate the selection, then reselect the index we want.

 This appears to fix the issue in all 3 dialogs of this type (Shell, Background, and Macro)