### PR TITLE
Use statbuf structure directly to store the handful of stat derived values

### DIFF
--- a/src/DocumentInfo.h
+++ b/src/DocumentInfo.h
@@ -12,9 +12,9 @@
 #include "WrapStyle.h"
 #include <QString>
 #include <QtGlobal>
-#include <qplatformdefs.h>
 #include <deque>
 #include <memory>
+#include <qplatformdefs.h>
 
 #ifdef Q_OS_MACOS
 #include <sys/stat.h>
@@ -28,7 +28,6 @@ struct DocumentInfo {
 	std::deque<UndoInfo> undo;                        // info for undoing last operation
 	LockReasons lockReasons;                          // all ways a file can be locked
 	std::unique_ptr<SmartIndentData> smartIndentData; // compiled macros for smart indent
-
 
 	QT_STATBUF statbuf = {}; // we care about MOST of the fields of this structure.
 							 // So instead of trying to match the OS specific types, just use it

--- a/src/DocumentInfo.h
+++ b/src/DocumentInfo.h
@@ -12,6 +12,7 @@
 #include "WrapStyle.h"
 #include <QString>
 #include <QtGlobal>
+#include <qplatformdefs.h>
 #include <deque>
 #include <memory>
 
@@ -28,21 +29,11 @@ struct DocumentInfo {
 	LockReasons lockReasons;                          // all ways a file can be locked
 	std::unique_ptr<SmartIndentData> smartIndentData; // compiled macros for smart indent
 
-#ifdef Q_OS_UNIX
-	uid_t uid   = 0; // last recorded user id of the file
-	gid_t gid   = 0; // last recorded group id of the file
-	mode_t mode = 0; // permissions of file being edited
-#elif defined(Q_OS_WIN)
-	// copied from the Windows version of the struct stat
-	unsigned short mode = 0;
-	short uid           = 0;
-	short gid           = 0;
-#endif
+
+	QT_STATBUF statbuf = {}; // we care about MOST of the fields of this structure.
+							 // So instead of trying to match the OS specific types, just use it
 
 	FileFormats fileFormat = FileFormats::Unix;                    // whether to save the file straight (Unix format), or convert it to MS DOS style with \r\n line breaks
-	time_t lastModTime     = 0;                                    // time of last modification to file
-	dev_t dev              = 0;                                    // device where the file resides
-	ino_t ino              = 0;                                    // file's inode
 	std::shared_ptr<TextBuffer> buffer;                            // holds the text being edited
 	int autoSaveCharCount               = 0;                       // count of single characters typed since last backup file generated
 	int autoSaveOpCount                 = 0;                       // count of editing operations

--- a/src/DocumentWidget.cpp
+++ b/src/DocumentWidget.cpp
@@ -2009,9 +2009,9 @@ void DocumentWidget::checkForChangesToFile() {
 		/* Can't stat the file --
 		 * maybe it's been deleted. The filename is now invalid */
 		info_->fileMissing = true;
-		info_->lastModTime = 1;
-		info_->dev         = 0;
-		info_->ino         = 0;
+		info_->statbuf.st_mtime = 1;
+		info_->statbuf.st_dev         = 0;
+		info_->statbuf.st_ino         = 0;
 
 		/* Warn the user, if they like to be warned (Maybe this should be
 		 * its own preference setting: GetPrefWarnFileDeleted()) */
@@ -2072,11 +2072,11 @@ void DocumentWidget::checkForChangesToFile() {
 
 	/* Check that the file's read-only status is still correct (but
 	   only if the file can still be opened successfully in read mode) */
-	if (info_->mode != statbuf.st_mode || info_->uid != statbuf.st_uid || info_->gid != statbuf.st_gid) {
+	if (info_->statbuf.st_mode != statbuf.st_mode || info_->statbuf.st_uid != statbuf.st_uid || info_->statbuf.st_gid != statbuf.st_gid) {
 
-		info_->mode = statbuf.st_mode;
-		info_->uid  = statbuf.st_uid;
-		info_->gid  = statbuf.st_gid;
+		info_->statbuf.st_mode = statbuf.st_mode;
+		info_->statbuf.st_uid  = statbuf.st_uid;
+		info_->statbuf.st_gid  = statbuf.st_gid;
 
 		QFile fp(fullname);
 		if (fp.open(QIODevice::ReadWrite) || fp.open(QIODevice::ReadOnly)) {
@@ -2093,9 +2093,9 @@ void DocumentWidget::checkForChangesToFile() {
 
 	/* Warn the user if the file has been modified, unless checking is
 	 * turned off or the user has already been warned. */
-	if (!silent && ((info_->lastModTime != 0 && info_->lastModTime != statbuf.st_mtime) || info_->fileMissing)) {
+	if (!silent && ((info_->statbuf.st_mtime != 0 && info_->statbuf.st_mtime != statbuf.st_mtime) || info_->fileMissing)) {
 
-		info_->lastModTime = 0; // Inhibit further warnings
+		info_->statbuf.st_mtime = 0; // Inhibit further warnings
 		info_->fileMissing = false;
 		if (!Preferences::GetPrefWarnFileMods()) {
 			return;
@@ -2103,7 +2103,7 @@ void DocumentWidget::checkForChangesToFile() {
 
 		if (Preferences::GetPrefWarnRealFileMods() && !compareDocumentToFile(fullname)) {
 			// Contents hasn't changed. Update the modification time.
-			info_->lastModTime = statbuf.st_mtime;
+			info_->statbuf.st_mtime = statbuf.st_mtime;
 			return;
 		}
 
@@ -2325,7 +2325,7 @@ void DocumentWidget::revertToSaved() {
 			closeDocument();
 		} else {
 			// Treat it like an externally modified file
-			info_->lastModTime = 0;
+			info_->statbuf.st_mtime = 0;
 			info_->fileMissing = false;
 		}
 		return;
@@ -2420,7 +2420,7 @@ bool DocumentWidget::saveDocument() {
 
 	/* Return success if the file is normal & unchanged or is a
 		read-only file. */
-	if ((!info_->fileChanged && !info_->fileMissing && info_->lastModTime > 0) || info_->lockReasons.isAnyLockedIgnoringPerm()) {
+	if ((!info_->fileChanged && !info_->fileMissing && info_->statbuf.st_mtime > 0) || info_->lockReasons.isAnyLockedIgnoringPerm()) {
 		return true;
 	}
 
@@ -2452,7 +2452,7 @@ bool DocumentWidget::saveDocument() {
 		messageBox.exec();
 		if (messageBox.clickedButton() != buttonContinue) {
 			// Cancel and mark file as externally modified
-			info_->lastModTime = 0;
+			info_->statbuf.st_mtime = 0;
 			info_->fileMissing = false;
 			return false;
 		}
@@ -2552,16 +2552,16 @@ bool DocumentWidget::doSave() {
 	// update the modification time
 	QT_STATBUF statbuf;
 	if (QT_STAT(fullname.toUtf8().data(), &statbuf) == 0) {
-		info_->lastModTime = statbuf.st_mtime;
+		info_->statbuf.st_mtime = statbuf.st_mtime;
 		info_->fileMissing = false;
-		info_->dev         = statbuf.st_dev;
-		info_->ino         = statbuf.st_ino;
+		info_->statbuf.st_dev         = statbuf.st_dev;
+		info_->statbuf.st_ino         = statbuf.st_ino;
 	} else {
 		// This needs to produce an error message -- the file can't be accessed!
-		info_->lastModTime = 0;
+		info_->statbuf.st_mtime = 0;
 		info_->fileMissing = true;
-		info_->dev         = 0;
-		info_->ino         = 0;
+		info_->statbuf.st_dev         = 0;
+		info_->statbuf.st_ino         = 0;
 	}
 
 	return true;
@@ -2638,9 +2638,9 @@ bool DocumentWidget::saveDocumentAs(const QString &newName, bool addWrap) {
 	removeBackupFile();
 	setPath(fi.pathname);
 	info_->filename = fi.filename;
-	info_->mode     = 0;
-	info_->uid      = 0;
-	info_->gid      = 0;
+	info_->statbuf.st_mode     = 0;
+	info_->statbuf.st_uid      = 0;
+	info_->statbuf.st_gid      = 0;
 
 	info_->lockReasons.clear();
 	const int retVal = doSave();
@@ -2853,7 +2853,7 @@ bool DocumentWidget::fileWasModifiedExternally() const {
 		return false;
 	}
 
-	if (info_->lastModTime == statbuf.st_mtime) {
+	if (info_->statbuf.st_mtime == statbuf.st_mtime) {
 		return false;
 	}
 
@@ -2871,9 +2871,9 @@ bool DocumentWidget::closeFileAndWindow(CloseMode preResponse) {
 	   just close it.  Otherwise ask for confirmation first. */
 	if (!info_->fileChanged &&
 		/* Normal File */
-		((!info_->fileMissing && info_->lastModTime > 0) ||
+		((!info_->fileMissing && info_->statbuf.st_mtime > 0) ||
 		 /* New File */
-		 (info_->fileMissing && info_->lastModTime == 0) ||
+		 (info_->fileMissing && info_->statbuf.st_mtime == 0) ||
 		 /* File deleted/modified externally, ignored by user. */
 		 !Preferences::GetPrefWarnFileMods())) {
 
@@ -2960,12 +2960,12 @@ void DocumentWidget::closeDocument() {
 		QString name = MainWindow::uniqueUntitledName();
 		info_->lockReasons.clear();
 
-		info_->mode        = 0;
-		info_->uid         = 0;
-		info_->gid         = 0;
-		info_->lastModTime = 0;
-		info_->dev         = 0;
-		info_->ino         = 0;
+		info_->statbuf.st_mode        = 0;
+		info_->statbuf.st_uid         = 0;
+		info_->statbuf.st_gid         = 0;
+		info_->statbuf.st_mtime = 0;
+		info_->statbuf.st_dev         = 0;
+		info_->statbuf.st_ino         = 0;
 		info_->filename    = name;
 		setPath(QString());
 
@@ -3228,12 +3228,12 @@ bool DocumentWidget::doOpen(const QString &name, const QString &path, int flags)
 		/* Any errors that happen after this point leave the window in a
 		 * "broken" state, and thus RevertToSaved will abandon the window if
 		 * info_->fileMissing is false and doOpen fails. */
-		info_->mode        = statbuf.st_mode;
-		info_->uid         = statbuf.st_uid;
-		info_->gid         = statbuf.st_gid;
-		info_->lastModTime = statbuf.st_mtime;
-		info_->dev         = statbuf.st_dev;
-		info_->ino         = statbuf.st_ino;
+		info_->statbuf.st_mode        = statbuf.st_mode;
+		info_->statbuf.st_uid         = statbuf.st_uid;
+		info_->statbuf.st_gid         = statbuf.st_gid;
+		info_->statbuf.st_mtime = statbuf.st_mtime;
+		info_->statbuf.st_dev         = statbuf.st_dev;
+		info_->statbuf.st_ino         = statbuf.st_ino;
 		info_->fileMissing = false;
 
 		// Detect and convert DOS and Macintosh format files
@@ -7322,7 +7322,7 @@ void DocumentWidget::setPath(const QDir &pathname) {
  * @return
  */
 dev_t DocumentWidget::device() const {
-	return info_->dev;
+	return info_->statbuf.st_dev;
 }
 
 /**
@@ -7330,7 +7330,7 @@ dev_t DocumentWidget::device() const {
  * @return
  */
 ino_t DocumentWidget::inode() const {
-	return info_->ino;
+	return info_->statbuf.st_ino;
 }
 
 /**

--- a/src/DocumentWidget.cpp
+++ b/src/DocumentWidget.cpp
@@ -2008,10 +2008,10 @@ void DocumentWidget::checkForChangesToFile() {
 
 		/* Can't stat the file --
 		 * maybe it's been deleted. The filename is now invalid */
-		info_->fileMissing = true;
+		info_->fileMissing      = true;
 		info_->statbuf.st_mtime = 1;
-		info_->statbuf.st_dev         = 0;
-		info_->statbuf.st_ino         = 0;
+		info_->statbuf.st_dev   = 0;
+		info_->statbuf.st_ino   = 0;
 
 		/* Warn the user, if they like to be warned (Maybe this should be
 		 * its own preference setting: GetPrefWarnFileDeleted()) */
@@ -2096,7 +2096,7 @@ void DocumentWidget::checkForChangesToFile() {
 	if (!silent && ((info_->statbuf.st_mtime != 0 && info_->statbuf.st_mtime != statbuf.st_mtime) || info_->fileMissing)) {
 
 		info_->statbuf.st_mtime = 0; // Inhibit further warnings
-		info_->fileMissing = false;
+		info_->fileMissing      = false;
 		if (!Preferences::GetPrefWarnFileMods()) {
 			return;
 		}
@@ -2326,7 +2326,7 @@ void DocumentWidget::revertToSaved() {
 		} else {
 			// Treat it like an externally modified file
 			info_->statbuf.st_mtime = 0;
-			info_->fileMissing = false;
+			info_->fileMissing      = false;
 		}
 		return;
 	}
@@ -2453,7 +2453,7 @@ bool DocumentWidget::saveDocument() {
 		if (messageBox.clickedButton() != buttonContinue) {
 			// Cancel and mark file as externally modified
 			info_->statbuf.st_mtime = 0;
-			info_->fileMissing = false;
+			info_->fileMissing      = false;
 			return false;
 		}
 	}
@@ -2553,15 +2553,15 @@ bool DocumentWidget::doSave() {
 	QT_STATBUF statbuf;
 	if (QT_STAT(fullname.toUtf8().data(), &statbuf) == 0) {
 		info_->statbuf.st_mtime = statbuf.st_mtime;
-		info_->fileMissing = false;
-		info_->statbuf.st_dev         = statbuf.st_dev;
-		info_->statbuf.st_ino         = statbuf.st_ino;
+		info_->fileMissing      = false;
+		info_->statbuf.st_dev   = statbuf.st_dev;
+		info_->statbuf.st_ino   = statbuf.st_ino;
 	} else {
 		// This needs to produce an error message -- the file can't be accessed!
 		info_->statbuf.st_mtime = 0;
-		info_->fileMissing = true;
-		info_->statbuf.st_dev         = 0;
-		info_->statbuf.st_ino         = 0;
+		info_->fileMissing      = true;
+		info_->statbuf.st_dev   = 0;
+		info_->statbuf.st_ino   = 0;
 	}
 
 	return true;
@@ -2637,10 +2637,10 @@ bool DocumentWidget::saveDocumentAs(const QString &newName, bool addWrap) {
 	// Change the name of the file and save it under the new name
 	removeBackupFile();
 	setPath(fi.pathname);
-	info_->filename = fi.filename;
-	info_->statbuf.st_mode     = 0;
-	info_->statbuf.st_uid      = 0;
-	info_->statbuf.st_gid      = 0;
+	info_->filename        = fi.filename;
+	info_->statbuf.st_mode = 0;
+	info_->statbuf.st_uid  = 0;
+	info_->statbuf.st_gid  = 0;
 
 	info_->lockReasons.clear();
 	const int retVal = doSave();
@@ -2960,13 +2960,13 @@ void DocumentWidget::closeDocument() {
 		QString name = MainWindow::uniqueUntitledName();
 		info_->lockReasons.clear();
 
-		info_->statbuf.st_mode        = 0;
-		info_->statbuf.st_uid         = 0;
-		info_->statbuf.st_gid         = 0;
+		info_->statbuf.st_mode  = 0;
+		info_->statbuf.st_uid   = 0;
+		info_->statbuf.st_gid   = 0;
 		info_->statbuf.st_mtime = 0;
-		info_->statbuf.st_dev         = 0;
-		info_->statbuf.st_ino         = 0;
-		info_->filename    = name;
+		info_->statbuf.st_dev   = 0;
+		info_->statbuf.st_ino   = 0;
+		info_->filename         = name;
 		setPath(QString());
 
 		markTable_.clear();
@@ -3228,13 +3228,13 @@ bool DocumentWidget::doOpen(const QString &name, const QString &path, int flags)
 		/* Any errors that happen after this point leave the window in a
 		 * "broken" state, and thus RevertToSaved will abandon the window if
 		 * info_->fileMissing is false and doOpen fails. */
-		info_->statbuf.st_mode        = statbuf.st_mode;
-		info_->statbuf.st_uid         = statbuf.st_uid;
-		info_->statbuf.st_gid         = statbuf.st_gid;
+		info_->statbuf.st_mode  = statbuf.st_mode;
+		info_->statbuf.st_uid   = statbuf.st_uid;
+		info_->statbuf.st_gid   = statbuf.st_gid;
 		info_->statbuf.st_mtime = statbuf.st_mtime;
-		info_->statbuf.st_dev         = statbuf.st_dev;
-		info_->statbuf.st_ino         = statbuf.st_ino;
-		info_->fileMissing = false;
+		info_->statbuf.st_dev   = statbuf.st_dev;
+		info_->statbuf.st_ino   = statbuf.st_ino;
+		info_->fileMissing      = false;
 
 		// Detect and convert DOS and Macintosh format files
 		if (Preferences::GetPrefForceOSConversion()) {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -45,15 +45,15 @@
 #include "shift.h"
 #include "userCmds.h"
 
+#include <QActionGroup>
 #include <QButtonGroup>
 #include <QClipboard>
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QMimeData>
 #include <QShortcut>
-#include <QToolTip>
 #include <QTimer>
-#include <QActionGroup>
+#include <QToolTip>
 #include <qplatformdefs.h>
 
 #include <cmath>

--- a/src/TextArea.cpp
+++ b/src/TextArea.cpp
@@ -3769,7 +3769,7 @@ void TextArea::cancelDrag() {
 	case NOT_CLICKED:
 		break;
 	default:
-		if(dragState != NOT_CLICKED) {
+		if (dragState != NOT_CLICKED) {
 			dragState_ = DRAG_CANCELED;
 		}
 		break;
@@ -7978,7 +7978,6 @@ bool TextArea::visibleLineContainsCursor(int visLine, TextCursor cursor) const {
 DocumentWidget *TextArea::document() const {
 	return document_;
 }
-
 
 /**
  * @brief TextArea::fixedFontHeight

--- a/src/TextAreaMimeData.cpp
+++ b/src/TextAreaMimeData.cpp
@@ -18,7 +18,7 @@ TextAreaMimeData::TextAreaMimeData(const std::shared_ptr<TextBuffer> &buffer)
  * @return
  */
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-QVariant TextAreaMimeData::retrieveData(const QString &mimeType, QMetaType  type) const {
+QVariant TextAreaMimeData::retrieveData(const QString &mimeType, QMetaType type) const {
 #else
 QVariant TextAreaMimeData::retrieveData(const QString &mimeType, QVariant::Type type) const {
 #endif

--- a/src/TextAreaMimeData.h
+++ b/src/TextAreaMimeData.h
@@ -20,7 +20,7 @@ public:
 
 protected:
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-	QVariant retrieveData(const QString &mimeType, QMetaType  type) const override;
+	QVariant retrieveData(const QString &mimeType, QMetaType type) const override;
 #else
 	QVariant retrieveData(const QString &mimeType, QVariant::Type type) const override;
 #endif


### PR DESCRIPTION
The majority of the fields in a statbuf were being replicated
in DocumentInfo to track various attributes of the document.
Unfortunately, this structure is very OS specific. So supporting
it properly was going to require a lot of #ifdefs...

So better to just use statbuf to store them!
Will also with issue #252 since several of the errors there was
regarding not knowing the types for OS/2 versions of these fields.