### PR TITLE
Working on making boost not required if we happen to have a C++17 compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ add_definitions(-DQT_NO_CAST_TO_ASCII)
 add_definitions(-DQT_NO_KEYWORDS)
 
 add_subdirectory(Util)
+add_subdirectory(Ext)
 add_subdirectory(src)
 add_subdirectory(libs)
 add_subdirectory(client)

--- a/Ext/CMakeLists.txt
+++ b/Ext/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.0)
+
+add_library(Ext INTERFACE)
+
+target_sources(Ext INTERFACE 
+	${CMAKE_CURRENT_SOURCE_DIR}/include/Ext/variant.h
+	${CMAKE_CURRENT_SOURCE_DIR}/include/Ext/optional.h
+	${CMAKE_CURRENT_SOURCE_DIR}/include/Ext/string_view.h)
+
+
+target_include_directories(Ext
+INTERFACE
+	${CMAKE_CURRENT_LIST_DIR}/include
+)
+
+set_property(TARGET Ext PROPERTY CXX_STANDARD ${TARGET_COMPILER_HIGHEST_STD_SUPPORTED})
+set_property(TARGET Ext PROPERTY CXX_EXTENSIONS OFF)

--- a/Ext/include/Ext/optional.h
+++ b/Ext/include/Ext/optional.h
@@ -1,0 +1,27 @@
+
+#ifndef EXT_OPTIONAL_H_
+#define EXT_OPTIONAL_H_
+
+#if __cplusplus >= 201703L
+#include <optional>
+
+namespace ext {
+
+template <class T>
+using optional = std::optional<T>;
+
+}
+
+#else
+#include <boost/optional.hpp>
+
+namespace ext {
+
+template <class T>
+using optional = boost::optional<T>;
+
+}
+
+#endif
+
+#endif

--- a/Ext/include/Ext/string_view.h
+++ b/Ext/include/Ext/string_view.h
@@ -1,0 +1,37 @@
+
+#ifndef EXT_STRING_VIEW_H_
+#define EXT_STRING_VIEW_H_
+
+#if __cplusplus >= 201703L
+#include <string_view>
+
+namespace ext {
+
+template <class Ch, class Tr = std::char_traits<Ch>>
+using basic_string_view = std::basic_string_view<Ch, Tr>;
+
+using string_view    = std::string_view;
+using wstring_view   = std::wstring_view;
+using u16string_view = std::u16string_view;
+using u32string_view = std::u32string_view;
+
+}
+#else
+
+#include <boost/utility/string_view.hpp>
+
+namespace ext {
+
+template <class Ch, class Tr = std::char_traits<Ch>>
+using basic_string_view = boost::basic_string_view<Ch, Tr>;
+
+using string_view    = boost::string_view;
+using wstring_view   = boost::wstring_view;
+using u16string_view = boost::u16string_view;
+using u32string_view = boost::u32string_view;
+
+}
+
+#endif
+
+#endif

--- a/Ext/include/Ext/variant.h
+++ b/Ext/include/Ext/variant.h
@@ -1,0 +1,52 @@
+
+#ifndef EXT_VARIANT_H_
+#define EXT_VARIANT_H_
+
+#if __cplusplus >= 201703L
+#include <variant>
+
+namespace ext {
+template <class... T>
+using variant = std::variant<T...>;
+
+using monostate = std::monostate;
+
+template <class... T>
+constexpr std::size_t index(const variant<T...> &v) {
+	return v.index();
+}
+
+using std::get;
+using std::get_if;
+
+}
+
+#else
+#include <boost/variant.hpp>
+namespace ext {
+template <class... T>
+using variant = boost::variant<T...>;
+
+using monostate = boost::blank;
+
+template <class... T>
+constexpr size_t index(const variant<T...> &v) {
+	return v.which();
+}
+
+using boost::get;
+
+template <class T, class Variant>
+auto get_if(const Variant *v) {
+	return boost::get<T>(v);
+}
+
+template <class T, class Variant>
+auto get_if(Variant *v) {
+	return boost::get<T>(v);
+}
+
+}
+#endif
+
+#endif

--- a/Interpreter/CMakeLists.txt
+++ b/Interpreter/CMakeLists.txt
@@ -34,8 +34,7 @@ PUBLIC
 	Qt5::Core
 	Util
 	GSL
-PRIVATE
-	Boost::boost
+	Ext
 )
 
 target_add_warnings(Interpreter)

--- a/Interpreter/DataValue.h
+++ b/Interpreter/DataValue.h
@@ -2,16 +2,16 @@
 #ifndef DATA_VALUE_H_
 #define DATA_VALUE_H_
 
-#include "Util/string_view.h"
+#include "Ext/string_view.h"
+#include "Ext/variant.h"
 
 #include <gsl/span>
 
+#include <limits>
 #include <map>
 #include <memory>
 #include <string>
 #include <system_error>
-
-#include <boost/variant.hpp>
 
 #include <QString>
 
@@ -33,8 +33,8 @@ struct ArrayIterator {
 	Array::iterator it;
 };
 
-using Data = boost::variant<
-	boost::blank,
+using Data = ext::variant<
+	ext::monostate,
 	int32_t,
 	std::string,
 	ArrayPtr,
@@ -87,9 +87,9 @@ inline DataValue make_value(bool n) {
 	return DV;
 }
 
-inline DataValue make_value(view::string_view str) {
+inline DataValue make_value(ext::string_view str) {
 	DataValue DV;
-	DV.value = str.to_string();
+	DV.value = std::string(str.begin(), str.end());
 	return DV;
 }
 
@@ -124,56 +124,56 @@ inline DataValue make_value(LibraryRoutine routine) {
 }
 
 inline bool is_unset(const DataValue &dv) {
-	return dv.value.which() == 0;
+	return ext::index(dv.value) == 0;
 }
 
 inline bool is_integer(const DataValue &dv) {
-	return dv.value.which() == 1;
+	return ext::index(dv.value) == 1;
 }
 
 inline bool is_string(const DataValue &dv) {
-	return dv.value.which() == 2;
+	return ext::index(dv.value) == 2;
 }
 
 inline bool is_array(const DataValue &dv) {
-	return dv.value.which() == 3;
+	return ext::index(dv.value) == 3;
 }
 
 inline std::string to_string(const DataValue &dv) {
 
-	if (auto n = boost::get<int>(&dv.value)) {
+	if (auto n = ext::get_if<int>(&dv.value)) {
 		return std::to_string(*n);
 	} else {
-		return boost::get<std::string>(dv.value);
+		return ext::get<std::string>(dv.value);
 	}
 }
 
 inline int to_integer(const DataValue &dv) {
-	return boost::get<int>(dv.value);
+	return ext::get<int>(dv.value);
 }
 
 inline Program *to_program(const DataValue &dv) {
-	return boost::get<Program *>(dv.value);
+	return ext::get<Program *>(dv.value);
 }
 
 inline LibraryRoutine to_subroutine(const DataValue &dv) {
-	return boost::get<LibraryRoutine>(dv.value);
+	return ext::get<LibraryRoutine>(dv.value);
 }
 
 inline DataValue *to_data_value(const DataValue &dv) {
-	return boost::get<DataValue *>(dv.value);
+	return ext::get<DataValue *>(dv.value);
 }
 
 inline Inst *to_instruction(const DataValue &dv) {
-	return boost::get<Inst *>(dv.value);
+	return ext::get<Inst *>(dv.value);
 }
 
 inline ArrayPtr to_array(const DataValue &dv) {
-	return boost::get<ArrayPtr>(dv.value);
+	return ext::get<ArrayPtr>(dv.value);
 }
 
 inline ArrayIterator to_iterator(const DataValue &dv) {
-	return boost::get<ArrayIterator>(dv.value);
+	return ext::get<ArrayIterator>(dv.value);
 }
 
 #endif

--- a/Interpreter/interpret.cpp
+++ b/Interpreter/interpret.cpp
@@ -688,7 +688,7 @@ Symbol *InstallIteratorSymbol() {
 /*
 ** Lookup a constant string by its value.
 */
-Symbol *LookupStringConstSymbol(view::string_view value) {
+Symbol *LookupStringConstSymbol(ext::string_view value) {
 
 	auto it = std::find_if(GlobalSymList.begin(), GlobalSymList.end(), [value](Symbol *s) {
 		return (s->type == CONST_SYM && is_string(s->value) && to_string(s->value) == value);
@@ -708,7 +708,7 @@ Symbol *InstallStringConstSymbolEx(const QString &str) {
 /*
 ** install string str in the global symbol table with a string name
 */
-Symbol *InstallStringConstSymbol(view::string_view str) {
+Symbol *InstallStringConstSymbol(ext::string_view str) {
 
 	static int stringConstIndex = 0;
 
@@ -729,7 +729,7 @@ Symbol *LookupSymbolEx(const QString &name) {
 	return LookupSymbol(name.toStdString());
 }
 
-Symbol *LookupSymbol(view::string_view name) {
+Symbol *LookupSymbol(ext::string_view name) {
 
 	// first look for a local symbol
 	auto local = std::find_if(LocalSymList.begin(), LocalSymList.end(), [name](Symbol *s) {

--- a/Interpreter/interpret.h
+++ b/Interpreter/interpret.h
@@ -3,7 +3,7 @@
 #define INTERPRET_H_
 
 #include "DataValue.h"
-#include "Util/string_view.h"
+#include "Ext/string_view.h"
 
 #include <gsl/span>
 
@@ -144,13 +144,13 @@ bool AddSym(Symbol *sym, QString *msg);
 Inst *GetPC();
 Program *FinishCreatingProgram();
 Symbol *InstallIteratorSymbol();
-Symbol *InstallStringConstSymbol(view::string_view str);
+Symbol *InstallStringConstSymbol(ext::string_view str);
 Symbol *InstallStringConstSymbolEx(const QString &str);
 Symbol *InstallSymbol(const std::string &name, SymTypes type, const DataValue &value);
 Symbol *InstallSymbolEx(const QString &name, enum SymTypes type, const DataValue &value);
-Symbol *LookupStringConstSymbol(view::string_view value);
+Symbol *LookupStringConstSymbol(ext::string_view value);
 Symbol *LookupSymbolEx(const QString &name);
-Symbol *LookupSymbol(view::string_view name);
+Symbol *LookupSymbol(ext::string_view name);
 void BeginCreatingProgram();
 void FillLoopAddrs(const Inst *breakAddr, const Inst *continueAddr);
 void StartLoopAddrList();

--- a/Regex/CMakeLists.txt
+++ b/Regex/CMakeLists.txt
@@ -37,6 +37,7 @@ target_include_directories(Regex PUBLIC
 
 target_link_libraries(Regex PUBLIC
 	Util
+	Ext
 )
 
 target_add_warnings(Regex)

--- a/Regex/Compile.cpp
+++ b/Regex/Compile.cpp
@@ -1874,7 +1874,7 @@ uint8_t *chunk(int paren, int *flag_param, len_range &range_param) {
  * Beware that the optimization and preparation code in here knows about
  * some of the structure of the compiled Regex.
  *----------------------------------------------------------------------*/
-Regex::Regex(view::string_view exp, int defaultFlags) {
+Regex::Regex(ext::string_view exp, int defaultFlags) {
 
 	Regex *const re = this;
 

--- a/Regex/Compile.h
+++ b/Regex/Compile.h
@@ -2,7 +2,7 @@
 #ifndef COMPILE_H_
 #define COMPILE_H_
 
-#include "Util/string_view.h"
+#include "Ext/string_view.h"
 #include <bitset>
 #include <vector>
 
@@ -10,8 +10,8 @@ class Regex;
 
 // Global work variables for 'CompileRE'.
 struct ParseContext {
-	view::string_view::iterator Reg_Parse; // Input scan ptr (scans user's regex)
-	view::string_view InputString;
+	ext::string_view::iterator Reg_Parse; // Input scan ptr (scans user's regex)
+	ext::string_view InputString;
 	std::vector<uint8_t> Code;
 	const char *Meta_Char;
 	size_t Reg_Size;                 // Size of compiled regex code.

--- a/Regex/Decompile.h
+++ b/Regex/Decompile.h
@@ -2,8 +2,8 @@
 #ifndef DECOMPILE_H_
 #define DECOMPILE_H_
 
+#include "Ext/variant.h"
 #include "Opcodes.h"
-#include <boost/variant.hpp>
 #include <string>
 #include <vector>
 class Regex;
@@ -46,7 +46,7 @@ struct Instruction6 {
 	uint16_t op2;
 };
 
-using Instruction = boost::variant<Instruction1, Instruction2, Instruction3, Instruction4, Instruction5, Instruction6>;
+using Instruction = ext::variant<Instruction1, Instruction2, Instruction3, Instruction4, Instruction5, Instruction6>;
 
 std::vector<Instruction> decompileRegex(const Regex &re);
 

--- a/Regex/Execute.h
+++ b/Regex/Execute.h
@@ -3,7 +3,7 @@
 #define EXECUTE_H_
 
 #include "Constants.h"
-#include "Util/string_view.h"
+#include "Ext/string_view.h"
 #include <array>
 #include <bitset>
 #include <cstdint>

--- a/Regex/Regex.cpp
+++ b/Regex/Regex.cpp
@@ -115,7 +115,7 @@ ParseContext pContext;
  * @param reverse
  * @return
  */
-bool Regex::execute(view::string_view string, bool reverse) {
+bool Regex::execute(ext::string_view string, bool reverse) {
 	return execute(string, 0, reverse);
 }
 
@@ -126,7 +126,7 @@ bool Regex::execute(view::string_view string, bool reverse) {
  * @param reverse
  * @return
  */
-bool Regex::execute(view::string_view string, size_t offset, bool reverse) {
+bool Regex::execute(ext::string_view string, size_t offset, bool reverse) {
 	return execute(string, offset, nullptr, reverse);
 }
 
@@ -138,7 +138,7 @@ bool Regex::execute(view::string_view string, size_t offset, bool reverse) {
  * @param reverse
  * @return
  */
-bool Regex::execute(view::string_view string, size_t offset, const char *delimiters, bool reverse) {
+bool Regex::execute(ext::string_view string, size_t offset, const char *delimiters, bool reverse) {
 	return execute(string, offset, string.size(), delimiters, reverse);
 }
 
@@ -151,7 +151,7 @@ bool Regex::execute(view::string_view string, size_t offset, const char *delimit
  * @param reverse
  * @return
  */
-bool Regex::execute(view::string_view string, size_t offset, size_t end_offset, const char *delimiters, bool reverse) {
+bool Regex::execute(ext::string_view string, size_t offset, size_t end_offset, const char *delimiters, bool reverse) {
 	return execute(
 		string,
 		offset,
@@ -173,7 +173,7 @@ bool Regex::execute(view::string_view string, size_t offset, size_t end_offset, 
  * @param reverse
  * @return
  */
-bool Regex::execute(view::string_view string, size_t offset, size_t end_offset, int prev, int succ, const char *delimiters, bool reverse) {
+bool Regex::execute(ext::string_view string, size_t offset, size_t end_offset, int prev, int succ, const char *delimiters, bool reverse) {
 	assert(offset <= end_offset);
 	assert(end_offset <= string.size());
 	return ExecRE(
@@ -193,7 +193,7 @@ bool Regex::execute(view::string_view string, size_t offset, size_t end_offset, 
  *
  * Builds a default delimiter table that persists across 'ExecRE' calls.
  *----------------------------------------------------------------------*/
-void Regex::SetDefaultWordDelimiters(view::string_view delimiters) {
+void Regex::SetDefaultWordDelimiters(ext::string_view delimiters) {
 	Default_Delimiters = makeDelimiterTable(delimiters);
 }
 
@@ -204,7 +204,7 @@ void Regex::SetDefaultWordDelimiters(view::string_view delimiters) {
  * lookup table for determining whether a character is a delimiter or
  * not.
  *----------------------------------------------------------------------*/
-std::bitset<256> Regex::makeDelimiterTable(view::string_view delimiters) {
+std::bitset<256> Regex::makeDelimiterTable(ext::string_view delimiters) {
 
 	std::bitset<256> table;
 

--- a/Regex/Regex.h
+++ b/Regex/Regex.h
@@ -3,8 +3,8 @@
 #define REGEX_H_
 
 #include "Constants.h"
+#include "Ext/string_view.h"
 #include "RegexError.h"
-#include "Util/string_view.h"
 
 #include <array>
 #include <bitset>
@@ -21,7 +21,7 @@ enum RE_DEFAULT_FLAG {
 
 class Regex {
 public:
-	Regex(view::string_view exp, int defaultFlags);
+	Regex(ext::string_view exp, int defaultFlags);
 	Regex(const Regex &) = delete;
 	Regex &operator=(const Regex &) = delete;
 	~Regex()                        = default;
@@ -47,7 +47,7 @@ public:
 	 * @param string  Text to search within
 	 * @param reverse Backward search.
 	 */
-	bool execute(view::string_view string, bool reverse = false);
+	bool execute(ext::string_view string, bool reverse = false);
 
 	/**
 	 * Match a 'Regex' structure against a string.
@@ -57,7 +57,7 @@ public:
 	 * @param offset  Offset into the string to begin search
 	 * @param reverse Backward search.
 	 */
-	bool execute(view::string_view string, size_t offset, bool reverse = false);
+	bool execute(ext::string_view string, size_t offset, bool reverse = false);
 
 	/**
 	 * Match a 'Regex' structure against a string.
@@ -68,7 +68,7 @@ public:
 	 * @param delimiters Word delimiters to use (nullptr for default)
 	 * @param reverse    Backward search.
 	 */
-	bool execute(view::string_view string, size_t offset, const char *delimiters, bool reverse = false);
+	bool execute(ext::string_view string, size_t offset, const char *delimiters, bool reverse = false);
 
 	/**
 	 * Match a 'Regex' structure against a string. Will only match things between offset and end_offset
@@ -80,7 +80,7 @@ public:
 	 * @param delimiters Word delimiters to use (nullptr for default)
 	 * @param reverse    Backward search.
 	 */
-	bool execute(view::string_view string, size_t offset, size_t end_offset, const char *delimiters, bool reverse = false);
+	bool execute(ext::string_view string, size_t offset, size_t end_offset, const char *delimiters, bool reverse = false);
 
 	/**
 	 * Match a 'Regex' structure against a string. Will only match things between offset and end_offset
@@ -94,7 +94,7 @@ public:
 	 * @param succ       Character immediately after 'end'.  Set to '\n' or -1 if true beginning of text.
 	 * @param reverse    Backward search.
 	 */
-	bool execute(view::string_view string, size_t offset, size_t end_offset, int prev, int succ, const char *delimiters, bool reverse = false);
+	bool execute(ext::string_view string, size_t offset, size_t end_offset, int prev, int succ, const char *delimiters, bool reverse = false);
 
 	/**
 	 * Perform substitutions after a 'Regex' match.
@@ -104,7 +104,7 @@ public:
 	 * @param dest
 	 * @return
 	 */
-	bool SubstituteRE(view::string_view source, std::string &dest) const noexcept;
+	bool SubstituteRE(ext::string_view source, std::string &dest) const noexcept;
 
 	/**
 	 * @brief isValid
@@ -115,7 +115,7 @@ public:
 public:
 	/* Builds a default delimiter table that persists across 'ExecRE' calls that
 	   is identical to 'delimiters'.*/
-	static void SetDefaultWordDelimiters(view::string_view delimiters);
+	static void SetDefaultWordDelimiters(ext::string_view delimiters);
 
 public:
 	std::array<const char *, MaxSubExpr> startp = {};      /* Captured text starting locations. */
@@ -129,7 +129,7 @@ public:
 
 public:
 	static std::bitset<256> Default_Delimiters;
-	static std::bitset<256> makeDelimiterTable(view::string_view delimiters);
+	static std::bitset<256> makeDelimiterTable(ext::string_view delimiters);
 };
 
 #endif

--- a/Regex/Substitute.cpp
+++ b/Regex/Substitute.cpp
@@ -9,7 +9,7 @@
 /*
 **  SubstituteRE - Perform substitutions after a 'Regex' match.
 */
-bool Regex::SubstituteRE(view::string_view source, std::string &dest) const noexcept {
+bool Regex::SubstituteRE(ext::string_view source, std::string &dest) const noexcept {
 
 	constexpr auto InvalidParenNumber = static_cast<size_t>(-1);
 

--- a/Regex/test/Test.cpp
+++ b/Regex/test/Test.cpp
@@ -6,11 +6,11 @@
 namespace {
 
 struct Test {
-	view::string_view input;
-	view::string_view output;
+	ext::string_view input;
+	ext::string_view output;
 };
 
-int test_regex_match(view::string_view regex, view::string_view input) {
+int test_regex_match(ext::string_view regex, ext::string_view input) {
 	Regex re(regex, REDFLT_STANDARD);
 
 	if (re.execute(input)) {

--- a/Util/CMakeLists.txt
+++ b/Util/CMakeLists.txt
@@ -111,7 +111,6 @@ PUBLIC
 	GSL
 	Qt5::Core
 	Qt5::Network
-	Boost::boost
 )
 
 target_add_warnings(Util)

--- a/Util/FileSystem.cpp
+++ b/Util/FileSystem.cpp
@@ -114,7 +114,7 @@ QString GetTrailingPathComponents(const QString &path, int components) {
 ** the sampled portion of a Macintosh looking file), the file is judged to be
 ** Unix format.
 */
-FileFormats FormatOfFile(view::string_view text) {
+FileFormats FormatOfFile(ext::string_view text) {
 
 	size_t nNewlines = 0;
 	size_t nReturns  = 0;

--- a/Util/String.cpp
+++ b/Util/String.cpp
@@ -30,7 +30,7 @@ QString ensure_newline(const QString &string) {
  * @param s
  * @return
  */
-std::string to_upper(view::string_view s) {
+std::string to_upper(ext::string_view s) {
 
 	std::string str;
 	str.reserve(s.size());
@@ -45,7 +45,7 @@ std::string to_upper(view::string_view s) {
  * @param s
  * @return
  */
-std::string to_lower(view::string_view s) {
+std::string to_lower(ext::string_view s) {
 
 	std::string str;
 	str.reserve(s.size());

--- a/Util/include/Util/FileSystem.h
+++ b/Util/include/Util/FileSystem.h
@@ -2,10 +2,10 @@
 #ifndef UTIL_FILESYSTEM_H_
 #define UTIL_FILESYSTEM_H_
 
-#include "string_view.h"
+#include "Ext/optional.h"
+#include "Ext/string_view.h"
 #include <QString>
 #include <QtGlobal>
-#include <boost/optional.hpp>
 #include <string>
 
 enum class FileFormats : int;
@@ -15,7 +15,7 @@ struct PathInfo {
 	QString filename;
 };
 
-FileFormats FormatOfFile(view::string_view text);
+FileFormats FormatOfFile(ext::string_view text);
 QString GetTrailingPathComponents(const QString &path, int components);
 QString NormalizePathname(const QString &pathname);
 QString ReadAnyTextFile(const QString &fileName, bool forceNL);

--- a/Util/include/Util/String.h
+++ b/Util/include/Util/String.h
@@ -2,13 +2,13 @@
 #ifndef UTIL_STRING_H_
 #define UTIL_STRING_H_
 
-#include "Util/string_view.h"
+#include "Ext/string_view.h"
 #include <string>
 
 class QString;
 
 QString ensure_newline(const QString &string);
-std::string to_upper(view::string_view s);
-std::string to_lower(view::string_view s);
+std::string to_upper(ext::string_view s);
+std::string to_lower(ext::string_view s);
 
 #endif

--- a/Util/include/Util/algorithm.h
+++ b/Util/include/Util/algorithm.h
@@ -2,7 +2,7 @@
 #ifndef ALGORITHM_H_
 #define ALGORITHM_H_
 
-#include "string_view.h"
+#include "Ext/string_view.h"
 #include <QtGlobal>
 #include <algorithm>
 
@@ -36,11 +36,11 @@ QT_WARNING_POP
 
 // string_view algorithms
 template <class Ch, class Tr = std::char_traits<Ch>>
-constexpr view::basic_string_view<Ch, Tr> substr(const Ch *first, const Ch *last) {
+constexpr ext::basic_string_view<Ch, Tr> substr(const Ch *first, const Ch *last) {
 
 	const Ch *data = first;
 	auto size      = std::distance(first, last);
-	return view::basic_string_view<Ch, Tr>(data, static_cast<size_t>(size));
+	return ext::basic_string_view<Ch, Tr>(data, static_cast<size_t>(size));
 }
 
 template <class Cont, class T, class Pred>

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -16,7 +16,6 @@ target_link_libraries(nc-ng PUBLIC
 	Qt5::Network
 	Util
 	Settings
-	Boost::boost
 )
 
 target_add_warnings(nc-ng)

--- a/client/nc.cpp
+++ b/client/nc.cpp
@@ -16,7 +16,7 @@
 #include <QString>
 #include <QThread>
 
-#include <boost/optional.hpp>
+#include "Ext/optional.h"
 #include <chrono>
 #include <iostream>
 #include <memory>
@@ -152,7 +152,7 @@ void printNcVersion() {
  * Converts command line into a command string suitable for passing to the
  * server
  */
-boost::optional<CommandLine> parseCommandLine(const QStringList &args) {
+ext::optional<CommandLine> parseCommandLine(const QStringList &args) {
 
 	CommandLine commandLine;
 	QString toDoCommand;
@@ -345,7 +345,7 @@ boost::optional<CommandLine> parseCommandLine(const QStringList &args) {
 CommandLine processCommandLine(const QStringList &args) {
 
 	// Convert command line arguments into a command string for the server
-	if (boost::optional<CommandLine> commandLine = parseCommandLine(args)) {
+	if (ext::optional<CommandLine> commandLine = parseCommandLine(args)) {
 		return *commandLine;
 	}
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -278,6 +278,7 @@ target_add_warnings(nedit-ng)
 
 target_link_libraries(nedit-ng
 PUBLIC
+    Ext
 	Util
 	Regex
 	Settings
@@ -290,7 +291,6 @@ PUBLIC
 	$<$<BOOL:${Qt5X11Extras_FOUND}>:Qt5::X11Extras>
 	$<$<BOOL:${X11_FOUND}>:X11>
 PRIVATE
-	Boost::boost
 	yaml-cpp
 )
 set_property(TARGET nedit-ng PROPERTY CXX_EXTENSIONS OFF)

--- a/src/CallTip.h
+++ b/src/CallTip.h
@@ -2,8 +2,8 @@
 #ifndef CALL_TIP_H_
 #define CALL_TIP_H_
 
+#include "Ext/variant.h"
 #include "TextCursor.h"
-#include <boost/variant.hpp>
 
 enum class TipHAlignMode {
 	Left,
@@ -22,7 +22,7 @@ enum class TipAlignMode {
 };
 
 // a cursor if it's anchored, otherwise it's a relative x position
-using CallTipPosition = boost::variant<int, TextCursor>;
+using CallTipPosition = ext::variant<int, TextCursor>;
 
 struct CallTip {
 	int ID                 = 0;                    // ID of displayed calltip.  Equals zero if none is displayed.

--- a/src/DialogDrawingStyles.cpp
+++ b/src/DialogDrawingStyles.cpp
@@ -246,13 +246,13 @@ bool DialogDrawingStyles::validateFields(Verbosity verbosity) {
  * @param mode
  * @return
  */
-boost::optional<HighlightStyle> DialogDrawingStyles::readFields(Verbosity verbosity) {
+ext::optional<HighlightStyle> DialogDrawingStyles::readFields(Verbosity verbosity) {
 
 	HighlightStyle hs;
 
 	QString name = ui.editName->text().simplified();
 	if (name.isNull()) {
-		return boost::none;
+		return {};
 	}
 
 	hs.name = name;
@@ -263,13 +263,13 @@ boost::optional<HighlightStyle> DialogDrawingStyles::readFields(Verbosity verbos
 								 tr("Please specify a name for the highlight style"));
 		}
 
-		return boost::none;
+		return {};
 	}
 
 	// read the color field
 	QString color = ui.editColorFG->text().simplified();
 	if (color.isEmpty()) {
-		return boost::none;
+		return {};
 	}
 
 	hs.color = color;
@@ -277,7 +277,7 @@ boost::optional<HighlightStyle> DialogDrawingStyles::readFields(Verbosity verbos
 		if (verbosity == Verbosity::Verbose) {
 			QMessageBox::warning(this, tr("Style Color"), tr("Please specify a color for the highlight style"));
 		}
-		return boost::none;
+		return {};
 	}
 
 	// Verify that the color is a valid X color spec
@@ -286,7 +286,7 @@ boost::optional<HighlightStyle> DialogDrawingStyles::readFields(Verbosity verbos
 		if (verbosity == Verbosity::Verbose) {
 			QMessageBox::warning(this, tr("Invalid Color"), tr("Invalid X color specification: %1").arg(hs.color));
 		}
-		return boost::none;
+		return {};
 	}
 
 	// read the background color field - this may be empty
@@ -307,7 +307,7 @@ boost::optional<HighlightStyle> DialogDrawingStyles::readFields(Verbosity verbos
 									 tr("Invalid X background color specification: %1").arg(hs.bgColor));
 			}
 
-			return boost::none;
+			return {};
 		}
 	}
 

--- a/src/DialogDrawingStyles.h
+++ b/src/DialogDrawingStyles.h
@@ -8,7 +8,7 @@
 
 #include <QPointer>
 
-#include <boost/optional.hpp>
+#include "Ext/optional.h"
 
 class DialogSyntaxPatterns;
 class HighlightStyleModel;
@@ -43,7 +43,7 @@ private:
 private:
 	bool applyDialogChanges();
 	bool validateFields(Verbosity verbosity);
-	boost::optional<HighlightStyle> readFields(Verbosity verbosity);
+	ext::optional<HighlightStyle> readFields(Verbosity verbosity);
 	bool updateCurrentItem();
 	bool updateCurrentItem(const QModelIndex &index);
 	int countPlainEntries() const;

--- a/src/DialogFind.cpp
+++ b/src/DialogFind.cpp
@@ -216,7 +216,7 @@ void DialogFind::setTextFieldFromDocument(DocumentWidget *document) {
 void DialogFind::buttonFind_clicked() {
 
 	// fetch find string, direction and type from the dialog
-	boost::optional<Fields> fields = readFields();
+	ext::optional<Fields> fields = readFields();
 	if (!fields) {
 		return;
 	}
@@ -242,7 +242,7 @@ void DialogFind::buttonFind_clicked() {
 ** strings and search type from the Find dialog.  If the strings are ok,
 ** save a copy in the search history, and return the fields
 */
-boost::optional<DialogFind::Fields> DialogFind::readFields() {
+ext::optional<DialogFind::Fields> DialogFind::readFields() {
 
 	Fields fields;
 
@@ -267,7 +267,7 @@ boost::optional<DialogFind::Fields> DialogFind::readFields() {
 				this,
 				tr("Regex Error"),
 				tr("Please respecify the search string:\n%1").arg(QString::fromLatin1(e.what())));
-			return boost::none;
+			return {};
 		}
 	} else {
 		if (ui.checkCase->isChecked()) {

--- a/src/DialogFind.h
+++ b/src/DialogFind.h
@@ -6,7 +6,7 @@
 #include "Direction.h"
 #include "SearchType.h"
 
-#include <boost/optional.hpp>
+#include "Ext/optional.h"
 
 #include "ui_DialogFind.h"
 
@@ -41,7 +41,7 @@ public:
 	void updateFindButton();
 
 private:
-	boost::optional<Fields> readFields();
+	ext::optional<Fields> readFields();
 
 private:
 	void textFind_textChanged(const QString &text);

--- a/src/DialogLanguageModes.cpp
+++ b/src/DialogLanguageModes.cpp
@@ -229,7 +229,7 @@ void DialogLanguageModes::buttonBox_clicked(QAbstractButton *button) {
 ** structure reflecting the current state of the selected language mode in the dialog.
 ** If any of the information is incorrect or missing, display a warning dialog.
 */
-boost::optional<LanguageMode> DialogLanguageModes::readFields(Verbosity verbosity) {
+ext::optional<LanguageMode> DialogLanguageModes::readFields(Verbosity verbosity) {
 
 	LanguageMode lm;
 
@@ -239,7 +239,7 @@ boost::optional<LanguageMode> DialogLanguageModes::readFields(Verbosity verbosit
 		if (verbosity == Verbosity::Verbose) {
 			QMessageBox::warning(this, tr("Language Mode Name"), tr("Please specify a name for the language mode"));
 		}
-		return boost::none;
+		return {};
 	}
 
 	lm.name = name;
@@ -262,7 +262,7 @@ boost::optional<LanguageMode> DialogLanguageModes::readFields(Verbosity verbosit
 			if (verbosity == Verbosity::Verbose) {
 				QMessageBox::warning(this, tr("Regex"), tr("Recognition expression:\n%1").arg(QString::fromLatin1(e.what())));
 			}
-			return boost::none;
+			return {};
 		}
 	}
 
@@ -276,7 +276,7 @@ boost::optional<LanguageMode> DialogLanguageModes::readFields(Verbosity verbosit
 			if (verbosity == Verbosity::Verbose) {
 				QMessageBox::warning(this, tr("Error reading Calltips"), tr("Can't read default calltips file(s):\n  \"%1\"\n").arg(tipsFile));
 			}
-			return boost::none;
+			return {};
 		} else if (!Tags::deleteTagsFile(tipsFile, Tags::SearchMode::TIP, false)) {
 			qCritical("NEdit: Internal error: Trouble deleting calltips file(s):\n  \"%s\"", qPrintable(tipsFile));
 		}
@@ -292,7 +292,7 @@ boost::optional<LanguageMode> DialogLanguageModes::readFields(Verbosity verbosit
 		int tabsSpacingValue = tabsSpacing.toInt(&ok);
 		if (!ok) {
 			QMessageBox::warning(this, tr("Warning"), tr("Can't read integer value \"%1\" in tab spacing").arg(tabsSpacing));
-			return boost::none;
+			return {};
 		}
 
 		lm.tabDist = tabsSpacingValue;
@@ -307,7 +307,7 @@ boost::optional<LanguageMode> DialogLanguageModes::readFields(Verbosity verbosit
 		int emulatedTabSpacingValue = emulatedTabSpacing.toInt(&ok);
 		if (!ok) {
 			QMessageBox::warning(this, tr("Warning"), tr("Can't read integer value \"%1\" in emulated tab spacing").arg(tabsSpacing));
-			return boost::none;
+			return {};
 		}
 
 		lm.emTabDist = emulatedTabSpacingValue;

--- a/src/DialogLanguageModes.h
+++ b/src/DialogLanguageModes.h
@@ -8,7 +8,7 @@
 
 #include <QPointer>
 
-#include <boost/optional.hpp>
+#include "Ext/optional.h"
 
 class DialogSyntaxPatterns;
 class LanguageMode;
@@ -44,7 +44,7 @@ private:
 	bool updateCurrentItem(const QModelIndex &index);
 	bool updateLanguageList(Verbosity verbosity);
 	bool updateLMList(Verbosity verbosity);
-	boost::optional<LanguageMode> readFields(Verbosity verbosity);
+	ext::optional<LanguageMode> readFields(Verbosity verbosity);
 	int countLanguageModes(const QString &name) const;
 	bool LMHasHighlightPatterns(const QString &name) const;
 

--- a/src/DialogMacros.cpp
+++ b/src/DialogMacros.cpp
@@ -258,7 +258,7 @@ bool DialogMacros::validateFields(Verbosity verbosity) {
 ** pointer to the new MenuItem structure as the function value, or nullptr on
 ** failure.
 */
-boost::optional<MenuItem> DialogMacros::readFields(Verbosity verbosity) {
+ext::optional<MenuItem> DialogMacros::readFields(Verbosity verbosity) {
 
 	QString nameText = ui.editName->text();
 
@@ -266,14 +266,14 @@ boost::optional<MenuItem> DialogMacros::readFields(Verbosity verbosity) {
 		if (verbosity == Verbosity::Verbose) {
 			QMessageBox::warning(this, tr("Menu Entry"), tr("Please specify a name for the menu item"));
 		}
-		return boost::none;
+		return {};
 	}
 
 	if (nameText.indexOf(QLatin1Char(':')) != -1) {
 		if (verbosity == Verbosity::Verbose) {
 			QMessageBox::warning(this, tr("Menu Entry"), tr("Menu item names may not contain colon (:) characters"));
 		}
-		return boost::none;
+		return {};
 	}
 
 	QString cmdText = ui.editMacro->toPlainText();
@@ -281,12 +281,12 @@ boost::optional<MenuItem> DialogMacros::readFields(Verbosity verbosity) {
 		if (verbosity == Verbosity::Verbose) {
 			QMessageBox::warning(this, tr("Command to Execute"), tr("Please specify macro command(s) to execute"));
 		}
-		return boost::none;
+		return {};
 	}
 
 	cmdText = ensure_newline(cmdText);
 	if (!checkMacroText(cmdText, verbosity)) {
-		return boost::none;
+		return {};
 	}
 
 	MenuItem menuItem;

--- a/src/DialogMacros.h
+++ b/src/DialogMacros.h
@@ -6,7 +6,7 @@
 #include "Verbosity.h"
 #include "ui_DialogMacros.h"
 
-#include <boost/optional.hpp>
+#include "Ext/optional.h"
 
 struct MenuItem;
 class MenuItemModel;
@@ -42,7 +42,7 @@ private:
 	bool checkMacroText(const QString &macro, Verbosity verbosity);
 	bool updateCurrentItem();
 	bool updateCurrentItem(const QModelIndex &index);
-	boost::optional<MenuItem> readFields(Verbosity verbosity);
+	ext::optional<MenuItem> readFields(Verbosity verbosity);
 
 private:
 	Ui::DialogMacros ui;

--- a/src/DialogMultiReplace.cpp
+++ b/src/DialogMultiReplace.cpp
@@ -87,7 +87,7 @@ void DialogMultiReplace::buttonReplace_clicked() {
 	/* Fetch the find and replace strings from the dialog;
 	 * they should have been validated already, but it is possible that the
 	 * user modified the strings again, so we should verify them again too. */
-	boost::optional<DialogReplace::Fields> fields = replace_->readFields();
+	ext::optional<DialogReplace::Fields> fields = replace_->readFields();
 	if (!fields) {
 		return;
 	}

--- a/src/DialogReplace.cpp
+++ b/src/DialogReplace.cpp
@@ -242,7 +242,7 @@ void DialogReplace::textFind_textChanged(const QString &text) {
 void DialogReplace::buttonFind_clicked() {
 
 	// Validate and fetch the find and replace strings from the dialog
-	boost::optional<Fields> fields = readFields();
+	ext::optional<Fields> fields = readFields();
 	if (!fields) {
 		return;
 	}
@@ -276,7 +276,7 @@ void DialogReplace::buttonFind_clicked() {
 void DialogReplace::buttonReplace_clicked() {
 
 	// Validate and fetch the find and replace strings from the dialog
-	boost::optional<Fields> fields = readFields();
+	ext::optional<Fields> fields = readFields();
 	if (!fields) {
 		return;
 	}
@@ -304,7 +304,7 @@ void DialogReplace::buttonReplace_clicked() {
 void DialogReplace::buttonReplaceFind_clicked() {
 
 	// Validate and fetch the find and replace strings from the dialog
-	boost::optional<Fields> fields = readFields();
+	ext::optional<Fields> fields = readFields();
 	if (!fields) {
 		return;
 	}
@@ -332,7 +332,7 @@ void DialogReplace::buttonReplaceFind_clicked() {
 void DialogReplace::buttonWindow_clicked() {
 
 	// Validate and fetch the find and replace strings from the dialog
-	boost::optional<Fields> fields = readFields();
+	ext::optional<Fields> fields = readFields();
 	if (!fields) {
 		return;
 	}
@@ -358,7 +358,7 @@ void DialogReplace::buttonWindow_clicked() {
 void DialogReplace::buttonSelection_clicked() {
 
 	// Validate and fetch the find and replace strings from the dialog
-	boost::optional<Fields> fields = readFields();
+	ext::optional<Fields> fields = readFields();
 	if (!fields) {
 		return;
 	}
@@ -384,7 +384,7 @@ void DialogReplace::buttonSelection_clicked() {
 void DialogReplace::buttonMulti_clicked() {
 
 	// Validate and fetch the find and replace strings from the dialog
-	boost::optional<Fields> fields = readFields();
+	ext::optional<Fields> fields = readFields();
 	if (!fields) {
 		return;
 	}
@@ -576,7 +576,7 @@ void DialogReplace::setActionButtons(bool replaceBtn, bool replaceFindBtn, bool 
 ** strings and search type from the Replace dialog.  If the strings are ok,
 ** save a copy in the search history, and return the fields
 */
-boost::optional<DialogReplace::Fields> DialogReplace::readFields() {
+ext::optional<DialogReplace::Fields> DialogReplace::readFields() {
 
 	Fields fields;
 
@@ -600,7 +600,7 @@ boost::optional<DialogReplace::Fields> DialogReplace::readFields() {
 			auto compiledRE = make_regex(replaceText, regexDefault);
 		} catch (const RegexError &e) {
 			QMessageBox::warning(this, tr("Search String"), tr("Please respecify the search string:\n%1").arg(QString::fromLatin1(e.what())));
-			return boost::none;
+			return {};
 		}
 	} else {
 		if (ui.checkCase->isChecked()) {

--- a/src/DialogReplace.h
+++ b/src/DialogReplace.h
@@ -6,8 +6,8 @@
 #include "Direction.h"
 #include "SearchType.h"
 
+#include "Ext/optional.h"
 #include <QPointer>
-#include <boost/optional.hpp>
 
 #include "ui_DialogReplace.h"
 
@@ -48,7 +48,7 @@ public:
 	void updateFindButton();
 
 private:
-	boost::optional<Fields> readFields();
+	ext::optional<Fields> readFields();
 
 private:
 	void textFind_textChanged(const QString &text);

--- a/src/DialogShellMenu.cpp
+++ b/src/DialogShellMenu.cpp
@@ -240,21 +240,21 @@ void DialogShellMenu::buttonBox_accepted() {
 ** pointer to the new MenuItem structure as the function value, or nullptr on
 ** failure.
 */
-boost::optional<MenuItem> DialogShellMenu::readFields(Verbosity verbosity) {
+ext::optional<MenuItem> DialogShellMenu::readFields(Verbosity verbosity) {
 
 	QString nameText = ui.editName->text();
 	if (nameText.isEmpty()) {
 		if (verbosity == Verbosity::Verbose) {
 			QMessageBox::warning(this, tr("Menu Entry"), tr("Please specify a name for the menu item"));
 		}
-		return boost::none;
+		return {};
 	}
 
 	if (nameText.indexOf(QLatin1Char(':')) != -1) {
 		if (verbosity == Verbosity::Verbose) {
 			QMessageBox::warning(this, tr("Menu Entry"), tr("Menu item names may not contain colon (:) characters"));
 		}
-		return boost::none;
+		return {};
 	}
 
 	QString cmdText = ui.editCommand->toPlainText();
@@ -262,7 +262,7 @@ boost::optional<MenuItem> DialogShellMenu::readFields(Verbosity verbosity) {
 		if (verbosity == Verbosity::Verbose) {
 			QMessageBox::warning(this, tr("Command to Execute"), tr("Please specify macro command(s) to execute"));
 		}
-		return boost::none;
+		return {};
 	}
 
 	MenuItem menuItem;

--- a/src/DialogShellMenu.h
+++ b/src/DialogShellMenu.h
@@ -6,7 +6,7 @@
 #include "Verbosity.h"
 #include "ui_DialogShellMenu.h"
 
-#include <boost/optional.hpp>
+#include "Ext/optional.h"
 
 struct MenuItem;
 class MenuItemModel;
@@ -40,7 +40,7 @@ private:
 	bool validateFields(Verbosity verbosity);
 	bool updateCurrentItem();
 	bool updateCurrentItem(const QModelIndex &index);
-	boost::optional<MenuItem> readFields(Verbosity verbosity);
+	ext::optional<MenuItem> readFields(Verbosity verbosity);
 
 private:
 	Ui::DialogShellMenu ui;

--- a/src/DialogSyntaxPatterns.cpp
+++ b/src/DialogSyntaxPatterns.cpp
@@ -454,7 +454,7 @@ void DialogSyntaxPatterns::buttonRestore_clicked() {
 
 	const QString languageMode = ui.comboLanguageMode->currentText();
 
-	boost::optional<PatternSet> patternSet = Highlight::readDefaultPatternSet(languageMode);
+	ext::optional<PatternSet> patternSet = Highlight::readDefaultPatternSet(languageMode);
 	if (!patternSet) {
 		QMessageBox::warning(
 			this,
@@ -790,7 +790,7 @@ std::unique_ptr<PatternSet> DialogSyntaxPatterns::getDialogPatternSet() {
 ** telling the user what's wrong (Passing "silent" as true, suppresses these
 ** dialogs).  Returns nullptr on error.
 */
-boost::optional<HighlightPattern> DialogSyntaxPatterns::readFields(Verbosity verbosity) {
+ext::optional<HighlightPattern> DialogSyntaxPatterns::readFields(Verbosity verbosity) {
 
 	HighlightPattern pat;
 
@@ -805,7 +805,7 @@ boost::optional<HighlightPattern> DialogSyntaxPatterns::readFields(Verbosity ver
 	// read the name field
 	QString name = ui.editPatternName->text().simplified();
 	if (name.isNull()) {
-		return boost::none;
+		return {};
 	}
 
 	pat.name = name;
@@ -813,7 +813,7 @@ boost::optional<HighlightPattern> DialogSyntaxPatterns::readFields(Verbosity ver
 		if (verbosity == Verbosity::Verbose) {
 			QMessageBox::warning(this, tr("Pattern Name"), tr("Please specify a name for the pattern"));
 		}
-		return boost::none;
+		return {};
 	}
 
 	// read the startRE field
@@ -822,7 +822,7 @@ boost::optional<HighlightPattern> DialogSyntaxPatterns::readFields(Verbosity ver
 		if (verbosity == Verbosity::Verbose) {
 			QMessageBox::warning(this, tr("Matching Regex"), tr("Please specify a regular expression to match"));
 		}
-		return boost::none;
+		return {};
 	}
 
 	/* Make sure coloring patterns contain only sub-expression references
@@ -851,7 +851,7 @@ boost::optional<HighlightPattern> DialogSyntaxPatterns::readFields(Verbosity ver
 					tr("Pattern Error"),
 					tr("The expression field in patterns which specify highlighting for a parent, must contain only sub-expression references in regular expression replacement form (&\\1\\2 etc.).  See Help -> Regular Expressions and Help -> Syntax Highlighting for more information"));
 			}
-			return boost::none;
+			return {};
 		}
 	}
 
@@ -862,7 +862,7 @@ boost::optional<HighlightPattern> DialogSyntaxPatterns::readFields(Verbosity ver
 			if (verbosity == Verbosity::Verbose) {
 				QMessageBox::warning(this, tr("Specify Parent Pattern"), tr("Please specify a parent pattern"));
 			}
-			return boost::none;
+			return {};
 		}
 
 		if (!parent.isNull()) {
@@ -880,7 +880,7 @@ boost::optional<HighlightPattern> DialogSyntaxPatterns::readFields(Verbosity ver
 			if (verbosity == Verbosity::Verbose) {
 				QMessageBox::warning(this, tr("Specify Regex"), tr("Please specify an ending regular expression"));
 			}
-			return boost::none;
+			return {};
 		}
 	}
 

--- a/src/DialogSyntaxPatterns.h
+++ b/src/DialogSyntaxPatterns.h
@@ -8,7 +8,7 @@
 
 #include <QPointer>
 
-#include <boost/optional.hpp>
+#include "Ext/optional.h"
 #include <memory>
 
 class HighlightPattern;
@@ -64,7 +64,7 @@ private:
 	bool updateCurrentItem();
 	bool updateCurrentItem(const QModelIndex &index);
 	bool updatePatternSet();
-	boost::optional<HighlightPattern> readFields(Verbosity verbosity);
+	ext::optional<HighlightPattern> readFields(Verbosity verbosity);
 	std::unique_ptr<PatternSet> getDialogPatternSet();
 	void setStyleMenu(const QString &name);
 	void updateLabels();

--- a/src/DialogWindowBackgroundMenu.cpp
+++ b/src/DialogWindowBackgroundMenu.cpp
@@ -241,7 +241,7 @@ bool DialogWindowBackgroundMenu::validateFields(Verbosity verbosity) {
 /*
 ** Read the name, accelerator, mnemonic, and command fields.
 */
-boost::optional<MenuItem> DialogWindowBackgroundMenu::readFields(Verbosity verbosity) {
+ext::optional<MenuItem> DialogWindowBackgroundMenu::readFields(Verbosity verbosity) {
 
 	QString nameText = ui.editName->text();
 
@@ -249,14 +249,14 @@ boost::optional<MenuItem> DialogWindowBackgroundMenu::readFields(Verbosity verbo
 		if (verbosity == Verbosity::Verbose) {
 			QMessageBox::warning(this, tr("Menu Entry"), tr("Please specify a name for the menu item"));
 		}
-		return boost::none;
+		return {};
 	}
 
 	if (nameText.indexOf(QLatin1Char(':')) != -1) {
 		if (verbosity == Verbosity::Verbose) {
 			QMessageBox::warning(this, tr("Menu Entry"), tr("Menu item names may not contain colon (:) characters"));
 		}
-		return boost::none;
+		return {};
 	}
 
 	QString cmdText = ui.editMacro->toPlainText();
@@ -264,12 +264,12 @@ boost::optional<MenuItem> DialogWindowBackgroundMenu::readFields(Verbosity verbo
 		if (verbosity == Verbosity::Verbose) {
 			QMessageBox::warning(this, tr("Command to Execute"), tr("Please specify macro command(s) to execute"));
 		}
-		return boost::none;
+		return {};
 	}
 
 	cmdText = ensure_newline(cmdText);
 	if (!checkMacroText(cmdText, verbosity)) {
-		return boost::none;
+		return {};
 	}
 
 	MenuItem menuItem;

--- a/src/DialogWindowBackgroundMenu.h
+++ b/src/DialogWindowBackgroundMenu.h
@@ -6,7 +6,7 @@
 #include "Verbosity.h"
 #include "ui_DialogWindowBackgroundMenu.h"
 
-#include <boost/optional.hpp>
+#include "Ext/optional.h"
 
 struct MenuItem;
 class MenuItemModel;
@@ -45,7 +45,7 @@ private:
 	bool checkMacroText(const QString &macro, Verbosity verbosity);
 	bool updateCurrentItem();
 	bool updateCurrentItem(const QModelIndex &index);
-	boost::optional<MenuItem> readFields(Verbosity verbosity);
+	ext::optional<MenuItem> readFields(Verbosity verbosity);
 
 private:
 	Ui::DialogWindowBackgroundMenu ui;

--- a/src/DocumentWidget.h
+++ b/src/DocumentWidget.h
@@ -8,6 +8,7 @@
 #include "CommandSource.h"
 #include "DocumentInfo.h"
 #include "ErrorSound.h"
+#include "Ext/string_view.h"
 #include "IndentStyle.h"
 #include "LanguageMode.h"
 #include "LockReasons.h"
@@ -19,7 +20,6 @@
 #include "TextBufferFwd.h"
 #include "UndoInfo.h"
 #include "Util/FileFormats.h"
-#include "Util/string_view.h"
 #include "Verbosity.h"
 #include "WrapStyle.h"
 
@@ -31,7 +31,7 @@
 
 #include <gsl/span>
 
-#include <boost/optional.hpp>
+#include "Ext/optional.h"
 
 #include <sys/stat.h>
 
@@ -89,8 +89,8 @@ Q_SIGNALS:
 public:
 	void dragEndCallback(TextArea *area, const DragEndEvent *event);
 	void dragStartCallback(TextArea *area);
-	void modifiedCallback(TextCursor pos, int64_t nInserted, int64_t nDeleted, int64_t nRestyled, view::string_view deletedText);
-	void modifiedCallback(TextCursor pos, int64_t nInserted, int64_t nDeleted, int64_t nRestyled, view::string_view deletedText, TextArea *area);
+	void modifiedCallback(TextCursor pos, int64_t nInserted, int64_t nDeleted, int64_t nRestyled, ext::string_view deletedText);
+	void modifiedCallback(TextCursor pos, int64_t nInserted, int64_t nDeleted, int64_t nRestyled, ext::string_view deletedText, TextArea *area);
 	void movedCallback(TextArea *area);
 	void smartIndentCallback(TextArea *area, SmartIndentEvent *event);
 
@@ -242,7 +242,7 @@ private:
 	bool saveDocumentAs(const QString &newName, bool addWrap);
 	bool writeBackupFile();
 	bool writeBckVersion();
-	boost::optional<TextCursor> findMatchingChar(char toMatch, Style styleToMatch, TextCursor charPos, TextCursor startLimit, TextCursor endLimit);
+	ext::optional<TextCursor> findMatchingChar(char toMatch, Style styleToMatch, TextCursor charPos, TextCursor startLimit, TextCursor endLimit);
 	int findAllMatches(TextArea *area, const QString &string);
 	size_t matchLanguageMode() const;
 	std::unique_ptr<HighlightData[]> compilePatterns(const std::vector<HighlightPattern> &patternSrc, Verbosity verbosity = Verbosity::Silent);
@@ -252,7 +252,7 @@ private:
 	void addRedoItem(UndoInfo &&redo);
 	void addUndoItem(UndoInfo &&undo);
 	void addWrapNewlines();
-	void appendDeletedText(view::string_view deletedText, int64_t deletedLen, Direction direction);
+	void appendDeletedText(ext::string_view deletedText, int64_t deletedLen, Direction direction);
 	void attachHighlightToWidget(TextArea *area);
 	void beginLearn();
 	void cancelLearning();
@@ -285,7 +285,7 @@ private:
 	void removeUndoItem();
 	void replay();
 	void revertToSaved();
-	void saveUndoInformation(TextCursor pos, int64_t nInserted, int64_t nDeleted, view::string_view deletedText);
+	void saveUndoInformation(TextCursor pos, int64_t nInserted, int64_t nDeleted, ext::string_view deletedText);
 	void setModeMessage(const QString &message);
 	void setWindowModified(bool modified);
 	void trimUndoList(size_t maxLength);

--- a/src/DragEndEvent.h
+++ b/src/DragEndEvent.h
@@ -2,15 +2,15 @@
 #ifndef DRAG_END_EVENT_H_
 #define DRAG_END_EVENT_H_
 
+#include "Ext/string_view.h"
 #include "TextCursor.h"
-#include "Util/string_view.h"
 #include <cstdint>
 
 struct DragEndEvent {
 	TextCursor startPos;
 	int64_t nCharsDeleted;
 	int64_t nCharsInserted;
-	view::string_view deletedText;
+	ext::string_view deletedText;
 };
 
 #endif

--- a/src/Highlight.cpp
+++ b/src/Highlight.cpp
@@ -105,7 +105,7 @@ TextCursor lastModified(const Ptr &buffer) {
 */
 bool isDefaultPatternSet(const PatternSet &patternSet) {
 
-	boost::optional<PatternSet> defaultPatSet = readDefaultPatternSet(patternSet.languageMode);
+	ext::optional<PatternSet> defaultPatSet = readDefaultPatternSet(patternSet.languageMode);
 	if (!defaultPatSet) {
 		return false;
 	}
@@ -795,14 +795,14 @@ bool readHighlightPattern(Input &in, QString *errMsg, HighlightPattern *pattern)
 ** structures, and a language mode name.  If unsuccessful, returns an empty
 ** vector message in "errMsg".
 */
-boost::optional<std::vector<HighlightPattern>> readHighlightPatterns(Input &in, QString *errMsg) {
+ext::optional<std::vector<HighlightPattern>> readHighlightPatterns(Input &in, QString *errMsg) {
 	// skip over blank space
 	in.skipWhitespaceNL();
 
 	// look for initial brace
 	if (*in != QLatin1Char('{')) {
 		*errMsg = tr("pattern list must begin with \"{\"");
-		return boost::none;
+		return {};
 	}
 	++in;
 
@@ -813,7 +813,7 @@ boost::optional<std::vector<HighlightPattern>> readHighlightPatterns(Input &in, 
 		in.skipWhitespaceNL();
 		if (in.atEnd()) {
 			*errMsg = tr("end of pattern list not found");
-			return boost::none;
+			return {};
 		} else if (*in == QLatin1Char('}')) {
 			++in;
 			break;
@@ -821,7 +821,7 @@ boost::optional<std::vector<HighlightPattern>> readHighlightPatterns(Input &in, 
 
 		HighlightPattern pat;
 		if (!readHighlightPattern(in, errMsg, &pat)) {
-			return boost::none;
+			return {};
 		}
 
 		ret.push_back(pat);
@@ -873,7 +873,7 @@ HighlightPattern readPatternYaml(const YAML::Node &patterns) {
  * @param it
  * @return
  */
-boost::optional<PatternSet> readPatternSetYaml(YAML::const_iterator it) {
+ext::optional<PatternSet> readPatternSetYaml(YAML::const_iterator it) {
 	struct HighlightError {
 		QString message;
 	};
@@ -921,14 +921,14 @@ boost::optional<PatternSet> readPatternSetYaml(YAML::const_iterator it) {
 		qWarning("NEdit: %s", qPrintable(ex.message));
 	}
 
-	return boost::none;
+	return {};
 }
 
 /*
 ** Read in a pattern set character string, and advance *inPtr beyond it.
 ** Returns nullptr and outputs an error to stderr on failure.
 */
-boost::optional<PatternSet> readPatternSet(Input &in) {
+ext::optional<PatternSet> readPatternSet(Input &in) {
 
 	struct HighlightError {
 		QString message;
@@ -956,7 +956,7 @@ boost::optional<PatternSet> readPatternSet(Input &in) {
 		/* look for "Default" keyword, and if it's there, return the default
 		   pattern set */
 		if (in.match(QLatin1String("Default"))) {
-			boost::optional<PatternSet> retPatSet = readDefaultPatternSet(patSet.languageMode);
+			ext::optional<PatternSet> retPatSet = readDefaultPatternSet(patSet.languageMode);
 			if (!retPatSet) {
 				Raise<HighlightError>(tr("No default pattern set"));
 			}
@@ -978,7 +978,7 @@ boost::optional<PatternSet> readPatternSet(Input &in) {
 		}
 
 		// read pattern list
-		boost::optional<std::vector<HighlightPattern>> patterns = readHighlightPatterns(in, &errMsg);
+		ext::optional<std::vector<HighlightPattern>> patterns = readHighlightPatterns(in, &errMsg);
 		if (!patterns) {
 			Raise<HighlightError>(errMsg);
 		}
@@ -995,7 +995,7 @@ boost::optional<PatternSet> readPatternSet(Input &in) {
 			tr("highlight pattern"),
 			error.message);
 
-		return boost::none;
+		return {};
 	}
 }
 
@@ -1033,7 +1033,7 @@ std::vector<PatternSet> readDefaultPatternSets() {
 
 	for (auto it = patternSets.begin(); it != patternSets.end(); ++it) {
 		// Read each pattern set, abort on error
-		if (boost::optional<PatternSet> patSet = readPatternSetYaml(it)) {
+		if (ext::optional<PatternSet> patSet = readPatternSetYaml(it)) {
 			defaultPatterns.push_back(*patSet);
 		}
 	}
@@ -1063,7 +1063,7 @@ std::vector<PatternSet> readDefaultPatternSets() {
 ** Note: This routine must be kept efficient.  It is called for every
 ** character typed.
 */
-void SyntaxHighlightModifyCB(TextCursor pos, int64_t nInserted, int64_t nDeleted, int64_t nRestyled, view::string_view deletedText, void *user) {
+void SyntaxHighlightModifyCB(TextCursor pos, int64_t nInserted, int64_t nDeleted, int64_t nRestyled, ext::string_view deletedText, void *user) {
 
 	Q_UNUSED(nRestyled)
 	Q_UNUSED(deletedText)
@@ -1463,7 +1463,7 @@ void LoadHighlightString(const QString &string) {
 
 		for (auto it = patternSets.begin(); it != patternSets.end(); ++it) {
 			// Read each pattern set, abort on error
-			boost::optional<PatternSet> patSet = readPatternSetYaml(it);
+			ext::optional<PatternSet> patSet = readPatternSetYaml(it);
 			if (!patSet) {
 				break;
 			}
@@ -1479,7 +1479,7 @@ void LoadHighlightString(const QString &string) {
 		Q_FOREVER {
 
 			// Read each pattern set, abort on error
-			boost::optional<PatternSet> patSet = readPatternSet(in);
+			ext::optional<PatternSet> patSet = readPatternSet(in);
 			if (!patSet) {
 				break;
 			}
@@ -1650,7 +1650,7 @@ PatternSet *FindPatternSet(const QString &languageMode) {
 ** Given a language mode name, determine if there is a default (built-in)
 ** pattern set available for that language mode, and if so, return it
 */
-boost::optional<PatternSet> readDefaultPatternSet(const QString &langModeName) {
+ext::optional<PatternSet> readDefaultPatternSet(const QString &langModeName) {
 
 	static const std::vector<PatternSet> defaultPatternSets = readDefaultPatternSets();
 
@@ -1662,7 +1662,7 @@ boost::optional<PatternSet> readDefaultPatternSet(const QString &langModeName) {
 		return *it;
 	}
 
-	return boost::none;
+	return {};
 }
 
 /*

--- a/src/Highlight.h
+++ b/src/Highlight.h
@@ -2,12 +2,12 @@
 #ifndef HIGHLIGHT_H_
 #define HIGHLIGHT_H_
 
+#include "Ext/string_view.h"
 #include "TextBufferFwd.h"
 #include "TextCursor.h"
 #include "Util/QtHelper.h"
-#include "Util/string_view.h"
 
-#include <boost/optional.hpp>
+#include "Ext/optional.h"
 #include <memory>
 #include <vector>
 
@@ -48,7 +48,7 @@ Q_DECLARE_NAMESPACE_TR(Highlight)
 struct ParseContext {
 	int *prev_char = nullptr;
 	QString delimiters;
-	view::string_view text;
+	ext::string_view text;
 };
 
 bool FontOfNamedStyleIsBold(const QString &styleName);
@@ -65,11 +65,11 @@ QString BgColorOfNamedStyle(const QString &styleName);
 QString FgColorOfNamedStyle(const QString &styleName);
 QString WriteHighlightString();
 size_t IndexOfNamedStyle(const QString &styleName);
-boost::optional<PatternSet> readDefaultPatternSet(const QString &langModeName);
+ext::optional<PatternSet> readDefaultPatternSet(const QString &langModeName);
 TextCursor backwardOneContext(TextBuffer *buf, const ReparseContext &context, TextCursor fromPos);
 TextCursor forwardOneContext(TextBuffer *buf, const ReparseContext &context, TextCursor fromPos);
 void RenameHighlightPattern(const QString &oldName, const QString &newName);
-void SyntaxHighlightModifyCB(TextCursor pos, int64_t nInserted, int64_t nDeleted, int64_t nRestyled, view::string_view deletedText, void *user);
+void SyntaxHighlightModifyCB(TextCursor pos, int64_t nInserted, int64_t nDeleted, int64_t nRestyled, ext::string_view deletedText, void *user);
 
 extern std::vector<HighlightStyle> HighlightStyles;
 extern std::vector<PatternSet> PatternSets;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -75,7 +75,7 @@ QVector<QString> PrevOpen;
 /*
 ** Extract the line and column number from the text string.
 */
-boost::optional<Location> StringToLineAndCol(const QString &text) {
+ext::optional<Location> StringToLineAndCol(const QString &text) {
 
 	static const QRegularExpression re(QLatin1String(
 		"^"
@@ -110,13 +110,13 @@ boost::optional<Location> StringToLineAndCol(const QString &text) {
 		}
 
 		if (r == -1 && c == -1) {
-			return boost::none;
+			return {};
 		}
 
 		return Location{r, c};
 	}
 
-	return boost::none;
+	return {};
 }
 
 /**
@@ -143,7 +143,7 @@ void changeCase(DocumentWidget *document, TextArea *area) {
 	TextBuffer *buf = document->buffer();
 
 	// Get the selection.  Use character before cursor if no selection
-	if (boost::optional<SelectionPos> pos = buf->BufGetSelectionPos()) {
+	if (ext::optional<SelectionPos> pos = buf->BufGetSelectionPos()) {
 		bool modified = false;
 
 		std::string text = buf->BufGetSelectionText();
@@ -2601,7 +2601,7 @@ void MainWindow::action_Goto_Line_Number(DocumentWidget *document, const QString
 		  [line]:[column]   (menu action)
 		  line              (macro call)
 		  line, column      (macro call) */
-	boost::optional<Location> loc = StringToLineAndCol(s);
+	ext::optional<Location> loc = StringToLineAndCol(s);
 	if (!loc) {
 		QApplication::beep();
 		return;
@@ -6264,7 +6264,7 @@ bool MainWindow::searchWindow(DocumentWidget *document, const QString &searchStr
 	}
 
 	// get the entire text buffer from the text area widget
-	view::string_view fileString = buffer->BufAsString();
+	ext::string_view fileString = buffer->BufAsString();
 
 	/* If we're already outside the boundaries, we must consider wrapping
 	   immediately (Note: fileEnd+1 is a valid starting position. Consider
@@ -6883,7 +6883,7 @@ void MainWindow::replaceInSelection(DocumentWidget *document, TextArea *area, co
 	TextBuffer *buffer = document->buffer();
 
 	// find out where the selection is
-	boost::optional<SelectionPos> pos = buffer->BufGetSelectionPos();
+	ext::optional<SelectionPos> pos = buffer->BufGetSelectionPos();
 	if (!pos) {
 		return;
 	}
@@ -6911,7 +6911,7 @@ void MainWindow::replaceInSelection(DocumentWidget *document, TextArea *area, co
 	int64_t realOffset   = 0;
 
 	Q_FOREVER {
-		boost::optional<Search::Result> searchResult = Search::SearchString(
+		ext::optional<Search::Result> searchResult = Search::SearchString(
 			fileString,
 			searchString,
 			Direction::Forward,
@@ -7120,11 +7120,11 @@ bool MainWindow::replaceAll(DocumentWidget *document, TextArea *area, const QStr
 	TextBuffer *buffer = document->buffer();
 
 	// view the entire text buffer from the text area widget as a string
-	view::string_view fileString = buffer->BufAsString();
+	ext::string_view fileString = buffer->BufAsString();
 
 	QString delimieters = document->getWindowDelimiters();
 
-	boost::optional<std::string> newFileString = Search::ReplaceAllInString(
+	ext::optional<std::string> newFileString = Search::ReplaceAllInString(
 		fileString,
 		searchString,
 		replaceString,
@@ -7260,7 +7260,7 @@ bool MainWindow::searchMatchesSelection(DocumentWidget *document, const QString 
 	// search for the string in the selection (we are only interested
 	// in an exact match, but the procedure SearchString does important
 	// stuff like applying the correct matching algorithm)
-	boost::optional<Search::Result> searchResult = Search::SearchString(
+	ext::optional<Search::Result> searchResult = Search::SearchString(
 		string,
 		searchString,
 		Direction::Forward,
@@ -7451,7 +7451,7 @@ void MainWindow::updateStatus(DocumentWidget *document, TextArea *area) {
 	QString slinecol;
 	const int64_t length = document->buffer()->length();
 
-	if (boost::optional<Location> loc = area->positionToLineAndCol(pos)) {
+	if (ext::optional<Location> loc = area->positionToLineAndCol(pos)) {
 		slinecol = tr("L: %1  C: %2").arg(loc->line).arg(loc->column);
 		if (showLineNumbers_) {
 			string = tr("%1%2%3 byte %4 of %5").arg(document->path(), document->filename(), format).arg(to_integer(pos)).arg(length);

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -84,7 +84,7 @@ QStringList readExtensionList(Input &in) {
 	return extensionList;
 }
 
-boost::optional<LanguageMode> readLanguageModeYaml(const YAML::Node &language) {
+ext::optional<LanguageMode> readLanguageModeYaml(const YAML::Node &language) {
 
 	struct ModeError {
 		QString message;
@@ -148,10 +148,10 @@ boost::optional<LanguageMode> readLanguageModeYaml(const YAML::Node &language) {
 		qWarning("NEdit: %s", qPrintable(ex.message));
 	}
 
-	return boost::none;
+	return {};
 }
 
-boost::optional<LanguageMode> readLanguageMode(Input &in) {
+ext::optional<LanguageMode> readLanguageMode(Input &in) {
 
 	struct ModeError {
 		QString message;
@@ -288,7 +288,7 @@ boost::optional<LanguageMode> readLanguageMode(Input &in) {
 			error.message);
 	}
 
-	return boost::none;
+	return {};
 }
 
 void loadLanguageModesString(const QString &string) {
@@ -307,7 +307,7 @@ void loadLanguageModesString(const QString &string) {
 
 		for (YAML::Node language : languages) {
 
-			boost::optional<LanguageMode> lm = readLanguageModeYaml(language);
+			ext::optional<LanguageMode> lm = readLanguageModeYaml(language);
 			if (!lm) {
 				break;
 			}
@@ -320,7 +320,7 @@ void loadLanguageModesString(const QString &string) {
 		Input in(&string);
 
 		Q_FOREVER {
-			boost::optional<LanguageMode> lm = readLanguageMode(in);
+			ext::optional<LanguageMode> lm = readLanguageMode(in);
 			if (!lm) {
 				break;
 			}

--- a/src/Rangeset.cpp
+++ b/src/Rangeset.cpp
@@ -546,9 +546,9 @@ QString Rangeset::name() const {
  * @brief Rangeset::RangesetSpan
  * @return
  */
-boost::optional<TextRange> Rangeset::RangesetSpan() const {
+ext::optional<TextRange> Rangeset::RangesetSpan() const {
 	if (ranges_.empty()) {
-		return boost::none;
+		return {};
 	}
 
 	TextRange r;
@@ -562,11 +562,11 @@ boost::optional<TextRange> Rangeset::RangesetSpan() const {
  * @param index
  * @return
  */
-boost::optional<TextRange> Rangeset::RangesetFindRangeNo(int index) const {
+ext::optional<TextRange> Rangeset::RangesetFindRangeNo(int index) const {
 
 	const auto n = static_cast<size_t>(index);
 	if (index < 0 || ranges_.size() <= n) {
-		return boost::none;
+		return {};
 	}
 
 	return ranges_[n];

--- a/src/Rangeset.h
+++ b/src/Rangeset.h
@@ -2,11 +2,11 @@
 #ifndef RANGESET_H_
 #define RANGESET_H_
 
+#include "Ext/optional.h"
 #include "TextBufferFwd.h"
 #include "TextCursor.h"
 #include "TextRange.h"
 #include <QColor>
-#include <boost/optional.hpp>
 #include <vector>
 
 // NOTE(eteran): a bit of an artificial limit, but we'll keep it for now
@@ -44,8 +44,8 @@ public:
 	RangesetInfo RangesetGetInfo() const;
 
 public:
-	boost::optional<TextRange> RangesetFindRangeNo(int index) const;
-	boost::optional<TextRange> RangesetSpan() const;
+	ext::optional<TextRange> RangesetFindRangeNo(int index) const;
+	ext::optional<TextRange> RangesetSpan() const;
 
 public:
 	int64_t RangesetCheckRangeOfPos(TextCursor pos);

--- a/src/RangesetTable.cpp
+++ b/src/RangesetTable.cpp
@@ -17,7 +17,7 @@ constexpr std::array<uint8_t, N_RANGESETS> rangeset_labels = {
 
 // --------------------------------------------------------------------------
 
-void RangesetBufModifiedCB(TextCursor pos, int64_t nInserted, int64_t nDeleted, int64_t nRestyled, view::string_view deletedText, void *user) {
+void RangesetBufModifiedCB(TextCursor pos, int64_t nInserted, int64_t nDeleted, int64_t nRestyled, ext::string_view deletedText, void *user) {
 	Q_UNUSED(nRestyled)
 
 	if (auto *table = static_cast<RangesetTable *>(user)) {

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -41,7 +41,7 @@ int HistStart = 0;
  * @param defaultFlags
  * @return
  */
-boost::optional<Search::Result> forwardRegexSearch(view::string_view string, view::string_view searchString, WrapMode wrap, int64_t beginPos, const char *delimiters, int defaultFlags) {
+ext::optional<Search::Result> forwardRegexSearch(ext::string_view string, ext::string_view searchString, WrapMode wrap, int64_t beginPos, const char *delimiters, int defaultFlags) {
 
 	try {
 		Regex compiledRE(searchString, defaultFlags);
@@ -59,7 +59,7 @@ boost::optional<Search::Result> forwardRegexSearch(view::string_view string, vie
 
 		// if wrap turned off, we're done
 		if (wrap == WrapMode::NoWrap) {
-			return boost::none;
+			return {};
 		}
 
 		// search from the beginning of the string to beginPos
@@ -73,13 +73,13 @@ boost::optional<Search::Result> forwardRegexSearch(view::string_view string, vie
 			return result;
 		}
 
-		return boost::none;
+		return {};
 	} catch (const RegexError &e) {
 		Q_UNUSED(e)
 		/* Note that this does not process errors from compiling the expression.
 		 * It assumes that the expression was checked earlier.
 		 */
-		return boost::none;
+		return {};
 	}
 }
 
@@ -93,7 +93,7 @@ boost::optional<Search::Result> forwardRegexSearch(view::string_view string, vie
  * @param defaultFlags
  * @return
  */
-boost::optional<Search::Result> backwardRegexSearch(view::string_view string, view::string_view searchString, WrapMode wrap, int64_t beginPos, const char *delimiters, int defaultFlags) {
+ext::optional<Search::Result> backwardRegexSearch(ext::string_view string, ext::string_view searchString, WrapMode wrap, int64_t beginPos, const char *delimiters, int defaultFlags) {
 
 	try {
 		Regex compiledRE(searchString, defaultFlags);
@@ -114,7 +114,7 @@ boost::optional<Search::Result> backwardRegexSearch(view::string_view string, vi
 
 		// if wrap turned off, we're done
 		if (wrap == WrapMode::NoWrap) {
-			return boost::none;
+			return {};
 		}
 
 		// search from the end of the string to beginPos
@@ -131,13 +131,13 @@ boost::optional<Search::Result> backwardRegexSearch(view::string_view string, vi
 			return result;
 		}
 
-		return boost::none;
+		return {};
 	} catch (const RegexError &e) {
 		Q_UNUSED(e)
 		/* Note that this does not process errors from compiling the expression.
 		 * It assumes that the expression was checked earlier.
 		 */
-		return boost::none;
+		return {};
 	}
 }
 
@@ -152,7 +152,7 @@ boost::optional<Search::Result> backwardRegexSearch(view::string_view string, vi
  * @param defaultFlags
  * @return
  */
-boost::optional<Search::Result> searchRegex(view::string_view string, view::string_view searchString, Direction direction, WrapMode wrap, int64_t beginPos, const char *delimiters, int defaultFlags) {
+ext::optional<Search::Result> searchRegex(ext::string_view string, ext::string_view searchString, Direction direction, WrapMode wrap, int64_t beginPos, const char *delimiters, int defaultFlags) {
 
 	switch (direction) {
 	case Direction::Forward:
@@ -174,18 +174,18 @@ boost::optional<Search::Result> searchRegex(view::string_view string, view::stri
  * @param beginPos
  * @return
  */
-boost::optional<Search::Result> searchLiteral(view::string_view string, view::string_view searchString, Direction direction, WrapMode wrap, int64_t beginPos, Qt::CaseSensitivity caseSensitivity) {
+ext::optional<Search::Result> searchLiteral(ext::string_view string, ext::string_view searchString, Direction direction, WrapMode wrap, int64_t beginPos, Qt::CaseSensitivity caseSensitivity) {
 
 	if (searchString.empty()) {
-		return boost::none;
+		return {};
 	}
 
 	std::string lcString;
 	std::string ucString;
 
 	if (caseSensitivity == Qt::CaseSensitive) {
-		lcString = searchString.to_string();
-		ucString = searchString.to_string();
+		lcString = std::string(searchString.begin(), searchString.end());
+		ucString = std::string(searchString.begin(), searchString.end());
 	} else {
 		ucString = to_upper(searchString);
 		lcString = to_lower(searchString);
@@ -195,7 +195,7 @@ boost::optional<Search::Result> searchLiteral(view::string_view string, view::st
 	const auto mid   = first + beginPos;
 	const auto last  = string.end();
 
-	auto do_search = [&](view::string_view::iterator it) -> boost::optional<Search::Result> {
+	auto do_search = [&](ext::string_view::iterator it) -> ext::optional<Search::Result> {
 		if (*it == ucString[0] || *it == lcString[0]) {
 			// matched first character
 			auto ucPtr   = ucString.begin();
@@ -219,30 +219,30 @@ boost::optional<Search::Result> searchLiteral(view::string_view string, view::st
 			}
 		}
 
-		return boost::none;
+		return {};
 	};
 
 	if (direction == Direction::Forward) {
 
 		// search from beginPos to end of string
 		for (auto it = mid; it != last; ++it) {
-			if (boost::optional<Search::Result> result = do_search(it)) {
+			if (ext::optional<Search::Result> result = do_search(it)) {
 				return result;
 			}
 		}
 
 		if (wrap == WrapMode::NoWrap) {
-			return boost::none;
+			return {};
 		}
 
 		// search from start of file to beginPos
 		for (auto it = first; it != mid; ++it) {
-			if (boost::optional<Search::Result> result = do_search(it)) {
+			if (ext::optional<Search::Result> result = do_search(it)) {
 				return result;
 			}
 		}
 
-		return boost::none;
+		return {};
 	} else {
 		// Direction::Backward
 		// search from beginPos to start of file.  A negative begin pos
@@ -250,24 +250,24 @@ boost::optional<Search::Result> searchLiteral(view::string_view string, view::st
 
 		if (beginPos >= 0) {
 			for (auto it = mid; it >= first; --it) {
-				if (boost::optional<Search::Result> result = do_search(it)) {
+				if (ext::optional<Search::Result> result = do_search(it)) {
 					return result;
 				}
 			}
 		}
 
 		if (wrap == WrapMode::NoWrap) {
-			return boost::none;
+			return {};
 		}
 
 		// search from end of file to beginPos
 		for (auto it = last; it >= mid; --it) {
-			if (boost::optional<Search::Result> result = do_search(it)) {
+			if (ext::optional<Search::Result> result = do_search(it)) {
 				return result;
 			}
 		}
 
-		return boost::none;
+		return {};
 	}
 }
 
@@ -285,10 +285,10 @@ boost::optional<Search::Result> searchLiteral(view::string_view string, view::st
 **  will suffice in that case.
 **
 */
-boost::optional<Search::Result> searchLiteralWord(view::string_view string, view::string_view searchString, Direction direction, WrapMode wrap, int64_t beginPos, const char *delimiters, Qt::CaseSensitivity caseSensitivity) {
+ext::optional<Search::Result> searchLiteralWord(ext::string_view string, ext::string_view searchString, Direction direction, WrapMode wrap, int64_t beginPos, const char *delimiters, Qt::CaseSensitivity caseSensitivity) {
 
 	if (searchString.empty()) {
-		return boost::none;
+		return {};
 	}
 
 	std::string lcString;
@@ -300,7 +300,7 @@ boost::optional<Search::Result> searchLiteralWord(view::string_view string, view
 	const auto mid   = first + beginPos;
 	const auto last  = string.end();
 
-	auto do_search_word = [&](const view::string_view::iterator it) -> boost::optional<Search::Result> {
+	auto do_search_word = [&](const ext::string_view::iterator it) -> ext::optional<Search::Result> {
 		if (*it == ucString[0] || *it == lcString[0]) {
 
 			// matched first character
@@ -333,7 +333,7 @@ boost::optional<Search::Result> searchLiteralWord(view::string_view string, view
 			}
 		}
 
-		return boost::none;
+		return {};
 	};
 
 	// If there is no language mode, we use the default list of delimiters
@@ -351,8 +351,8 @@ boost::optional<Search::Result> searchLiteralWord(view::string_view string, view
 	}
 
 	if (caseSensitivity == Qt::CaseSensitive) {
-		ucString = searchString.to_string();
-		lcString = searchString.to_string();
+		lcString = std::string(searchString.begin(), searchString.end());
+		ucString = std::string(searchString.begin(), searchString.end());
 	} else {
 		ucString = to_upper(searchString);
 		lcString = to_lower(searchString);
@@ -362,22 +362,22 @@ boost::optional<Search::Result> searchLiteralWord(view::string_view string, view
 
 		// search from beginPos to end of string
 		for (auto it = mid; it != last; ++it) {
-			if (boost::optional<Search::Result> result = do_search_word(it)) {
+			if (ext::optional<Search::Result> result = do_search_word(it)) {
 				return result;
 			}
 		}
 
 		if (wrap == WrapMode::NoWrap) {
-			return boost::none;
+			return {};
 		}
 
 		// search from start of file to beginPos
 		for (auto it = first; it != mid; ++it) {
-			if (boost::optional<Search::Result> result = do_search_word(it)) {
+			if (ext::optional<Search::Result> result = do_search_word(it)) {
 				return result;
 			}
 		}
-		return boost::none;
+		return {};
 	} else {
 		// Direction::Backward
 		// search from beginPos to start of file. A negative begin pos
@@ -385,23 +385,23 @@ boost::optional<Search::Result> searchLiteralWord(view::string_view string, view
 
 		if (beginPos >= 0) {
 			for (auto it = mid; it >= first; --it) {
-				if (boost::optional<Search::Result> result = do_search_word(it)) {
+				if (ext::optional<Search::Result> result = do_search_word(it)) {
 					return result;
 				}
 			}
 		}
 
 		if (wrap == WrapMode::NoWrap) {
-			return boost::none;
+			return {};
 		}
 
 		// search from end of file to beginPos
 		for (auto it = last; it >= mid; --it) {
-			if (boost::optional<Search::Result> result = do_search_word(it)) {
+			if (ext::optional<Search::Result> result = do_search_word(it)) {
 				return result;
 			}
 		}
-		return boost::none;
+		return {};
 	}
 }
 
@@ -411,7 +411,7 @@ boost::optional<Search::Result> searchLiteralWord(view::string_view string, view
 ** for regular expression "<" and ">" characters, or simply passed as nullptr
 ** for the default delimiter set.
 */
-boost::optional<Search::Result> SearchStringEx(view::string_view string, view::string_view searchString, Direction direction, SearchType searchType, WrapMode wrap, int64_t beginPos, const char *delimiters) {
+ext::optional<Search::Result> SearchStringEx(ext::string_view string, ext::string_view searchString, Direction direction, SearchType searchType, WrapMode wrap, int64_t beginPos, const char *delimiters) {
 	switch (searchType) {
 	case SearchType::CaseSenseWord:
 		return searchLiteralWord(string, searchString, direction, wrap, beginPos, delimiters, Qt::CaseSensitive);
@@ -439,7 +439,7 @@ boost::optional<Search::Result> SearchStringEx(view::string_view string, view::s
 ** code to continue using strings to represent the search and replace
 ** items.
 */
-bool replaceUsingRegex(view::string_view searchStr, view::string_view replaceStr, view::string_view sourceStr, int64_t beginPos, std::string &dest, int prevChar, const char *delimiters, int defaultFlags) {
+bool replaceUsingRegex(ext::string_view searchStr, ext::string_view replaceStr, ext::string_view sourceStr, int64_t beginPos, std::string &dest, int prevChar, const char *delimiters, int defaultFlags) {
 	try {
 		Regex compiledRE(searchStr, defaultFlags);
 		compiledRE.execute(sourceStr, static_cast<size_t>(beginPos), sourceStr.size(), prevChar, -1, delimiters, false);
@@ -458,14 +458,14 @@ bool replaceUsingRegex(view::string_view searchStr, view::string_view replaceStr
 ** first replacement (returned in "copyStart", and the end of the last
 ** replacement (returned in "copyEnd")
 */
-boost::optional<std::string> Search::ReplaceAllInString(view::string_view inString, const QString &searchString, const QString &replaceString, SearchType searchType, int64_t *copyStart, int64_t *copyEnd, const QString &delimiters) {
+ext::optional<std::string> Search::ReplaceAllInString(ext::string_view inString, const QString &searchString, const QString &replaceString, SearchType searchType, int64_t *copyStart, int64_t *copyEnd, const QString &delimiters) {
 
 	Result searchResult;
 	int64_t lastEndPos;
 
 	// reject empty string
 	if (searchString.isNull()) {
-		return boost::none;
+		return {};
 	}
 
 	/* rehearse the search first to determine the size of the buffer needed
@@ -525,7 +525,7 @@ boost::optional<std::string> Search::ReplaceAllInString(view::string_view inStri
 	}
 
 	if (nFound == 0) {
-		return boost::none;
+		return {};
 	}
 
 	const int64_t copyLen = *copyEnd - *copyStart;
@@ -599,7 +599,7 @@ boost::optional<std::string> Search::ReplaceAllInString(view::string_view inStri
  * @param delimiters
  * @return
  */
-boost::optional<Search::Result> Search::SearchString(view::string_view string, const QString &searchString, Direction direction, SearchType searchType, WrapMode wrap, int64_t beginPos, const QString &delimiters) {
+ext::optional<Search::Result> Search::SearchString(ext::string_view string, const QString &searchString, Direction direction, SearchType searchType, WrapMode wrap, int64_t beginPos, const QString &delimiters) {
 	return SearchStringEx(string, searchString.toStdString(), direction, searchType, wrap, beginPos, delimiters.isNull() ? nullptr : delimiters.toLatin1().data());
 }
 
@@ -615,11 +615,11 @@ boost::optional<Search::Result> Search::SearchString(view::string_view string, c
  * @param delimiters
  * @return
  */
-bool Search::SearchString(view::string_view string, const QString &searchString, Direction direction, SearchType searchType, WrapMode wrap, int64_t beginPos, Result *result, const QString &delimiters) {
+bool Search::SearchString(ext::string_view string, const QString &searchString, Direction direction, SearchType searchType, WrapMode wrap, int64_t beginPos, Result *result, const QString &delimiters) {
 
 	assert(result);
 
-	if (boost::optional<Result> r = SearchString(string, searchString, direction, searchType, wrap, beginPos, delimiters)) {
+	if (ext::optional<Result> r = SearchString(string, searchString, direction, searchType, wrap, beginPos, delimiters)) {
 		*result = *r;
 		return true;
 	}
@@ -627,7 +627,7 @@ bool Search::SearchString(view::string_view string, const QString &searchString,
 	return false;
 }
 
-bool Search::replaceUsingRE(const QString &searchStr, const QString &replaceStr, view::string_view sourceStr, int64_t beginPos, std::string &dest, int prevChar, const QString &delimiters, int defaultFlags) {
+bool Search::replaceUsingRE(const QString &searchStr, const QString &replaceStr, ext::string_view sourceStr, int64_t beginPos, std::string &dest, int prevChar, const QString &delimiters, int defaultFlags) {
 	return replaceUsingRegex(
 		searchStr.toStdString(),
 		replaceStr.toStdString(),

--- a/src/Search.h
+++ b/src/Search.h
@@ -3,12 +3,12 @@
 #define SEARCH_H_
 
 #include "Direction.h"
+#include "Ext/string_view.h"
 #include "SearchType.h"
-#include "Util/string_view.h"
 #include "WrapMode.h"
 
+#include "Ext/optional.h"
 #include <QString>
-#include <boost/optional.hpp>
 
 class DocumentWidget;
 class MainWindow;
@@ -31,12 +31,12 @@ struct Result {
 };
 
 bool isRegexType(SearchType searchType);
-bool replaceUsingRE(const QString &searchStr, const QString &replaceStr, view::string_view sourceStr, int64_t beginPos, std::string &dest, int prevChar, const QString &delimiters, int defaultFlags);
-bool SearchString(view::string_view string, const QString &searchString, Direction direction, SearchType searchType, WrapMode wrap, int64_t beginPos, Result *result, const QString &delimiters);
-boost::optional<Result> SearchString(view::string_view string, const QString &searchString, Direction direction, SearchType searchType, WrapMode wrap, int64_t beginPos, const QString &delimiters);
+bool replaceUsingRE(const QString &searchStr, const QString &replaceStr, ext::string_view sourceStr, int64_t beginPos, std::string &dest, int prevChar, const QString &delimiters, int defaultFlags);
+bool SearchString(ext::string_view string, const QString &searchString, Direction direction, SearchType searchType, WrapMode wrap, int64_t beginPos, Result *result, const QString &delimiters);
+ext::optional<Result> SearchString(ext::string_view string, const QString &searchString, Direction direction, SearchType searchType, WrapMode wrap, int64_t beginPos, const QString &delimiters);
 int defaultRegexFlags(SearchType searchType);
 int historyIndex(int nCycles);
-boost::optional<std::string> ReplaceAllInString(view::string_view inString, const QString &searchString, const QString &replaceString, SearchType searchType, int64_t *copyStart, int64_t *copyEnd, const QString &delimiters);
+ext::optional<std::string> ReplaceAllInString(ext::string_view inString, const QString &searchString, const QString &replaceString, SearchType searchType, int64_t *copyStart, int64_t *copyEnd, const QString &delimiters);
 void saveSearchHistory(const QString &searchString, QString replaceString, SearchType searchType, bool isIncremental);
 HistoryEntry *HistoryByIndex(int index);
 

--- a/src/SmartIndentEvent.h
+++ b/src/SmartIndentEvent.h
@@ -2,8 +2,8 @@
 #ifndef SMART_INDENT_EVENT_H_
 #define SMART_INDENT_EVENT_H_
 
+#include "Ext/string_view.h"
 #include "TextCursor.h"
-#include "Util/string_view.h"
 
 enum SmartIndentReason {
 	NEWLINE_INDENT_NEEDED,
@@ -14,7 +14,7 @@ struct SmartIndentEvent {
 	SmartIndentReason reason;
 	TextCursor pos;
 	int request;
-	view::string_view charsTyped;
+	ext::string_view charsTyped;
 };
 
 #endif

--- a/src/Tags.cpp
+++ b/src/Tags.cpp
@@ -100,7 +100,7 @@ QList<Tag> getTagFromTable(QMultiHash<QString, Tag> &table, const QString &name)
  * separators (for now) are \n.  If the end of string is reached before n
  * lines, return the number of lines advanced, else normally return -1.
  */
-int64_t moveAheadNLines(view::string_view str, int64_t &pos, int64_t n) {
+int64_t moveAheadNLines(ext::string_view str, int64_t &pos, int64_t n) {
 
 	int64_t i = n;
 	while (static_cast<size_t>(pos) != str.size() && n > 0) {
@@ -1113,7 +1113,7 @@ QList<Tag> lookupTag(const QString &name, SearchMode mode) {
 ** into NEdit compatible regular expressions and does the search.
 ** Etags search expressions are plain literals strings, which
 */
-bool fakeRegExSearch(view::string_view buffer, const QString &searchString, int64_t *startPos, int64_t *endPos) {
+bool fakeRegExSearch(ext::string_view buffer, const QString &searchString, int64_t *startPos, int64_t *endPos) {
 
 	if (searchString.isEmpty()) {
 		return false;
@@ -1123,7 +1123,7 @@ bool fakeRegExSearch(view::string_view buffer, const QString &searchString, int6
 	Direction dir;
 	bool ctagsMode;
 
-	view::string_view fileString = buffer;
+	ext::string_view fileString = buffer;
 
 	// determine search direction and start position
 	if (*startPos != -1) { // etags mode!

--- a/src/Tags.h
+++ b/src/Tags.h
@@ -3,8 +3,8 @@
 #define TAGS_H_
 
 #include "CallTip.h"
+#include "Ext/string_view.h"
 #include "Util/QtHelper.h"
-#include "Util/string_view.h"
 
 #include <deque>
 
@@ -62,7 +62,7 @@ QList<Tag> lookupTag(const QString &name, SearchMode mode);
 bool addRelTagsFile(const QString &tagSpec, const QString &windowPath, SearchMode mode);
 bool addTagsFile(const QString &tagSpec, SearchMode mode);
 bool deleteTagsFile(const QString &tagSpec, SearchMode mode, bool force_unload);
-bool fakeRegExSearch(view::string_view buffer, const QString &searchString, int64_t *startPos, int64_t *endPos);
+bool fakeRegExSearch(ext::string_view buffer, const QString &searchString, int64_t *startPos, int64_t *endPos);
 int tagsShowCalltip(TextArea *area, const QString &text);
 void showMatchingCalltip(QWidget *parent, TextArea *area, int id);
 

--- a/src/TextArea.cpp
+++ b/src/TextArea.cpp
@@ -64,7 +64,7 @@ namespace {
  * @param len
  * @return
  */
-QString asciiToUnicode(view::string_view string) {
+QString asciiToUnicode(ext::string_view string) {
 	QString s;
 	s.reserve(static_cast<int>(string.size()));
 
@@ -245,7 +245,7 @@ void bufPreDeleteCB(TextCursor pos, int64_t nDeleted, void *arg) {
 /*
 ** Callback attached to the text buffer to receive modification information
 */
-void bufModifiedCB(TextCursor pos, int64_t nInserted, int64_t nDeleted, int64_t nRestyled, view::string_view deletedText, void *arg) {
+void bufModifiedCB(TextCursor pos, int64_t nInserted, int64_t nDeleted, int64_t nRestyled, ext::string_view deletedText, void *arg) {
 	auto area = static_cast<TextArea *>(arg);
 	area->bufModifiedCallback(pos, nInserted, nDeleted, nRestyled, deletedText);
 }
@@ -253,7 +253,7 @@ void bufModifiedCB(TextCursor pos, int64_t nInserted, int64_t nDeleted, int64_t 
 /*
 ** Count the number of newlines in a text string
 */
-int countNewlines(view::string_view string) {
+int countNewlines(ext::string_view string) {
 	return static_cast<int>(std::count(string.begin(), string.end(), '\n'));
 }
 
@@ -725,7 +725,7 @@ void TextArea::beginningOfLine(EventFlags flags) {
 		if (smartHome_) {
 			// if the user presses home, go to the first non-whitespace character
 			// if they are already there, go to the actual begining of the line
-			if (boost::optional<TextCursor> p = spanForward(buffer_, lineStart, " \t", false)) {
+			if (ext::optional<TextCursor> p = spanForward(buffer_, lineStart, " \t", false)) {
 				if (p != insertPos) {
 					lineStart = *p;
 				}
@@ -1422,7 +1422,7 @@ void TextArea::bufPreDeleteCallback(TextCursor pos, int64_t nDeleted) {
  * @param nRestyled
  * @param deletedText
  */
-void TextArea::bufModifiedCallback(TextCursor pos, int64_t nInserted, int64_t nDeleted, int64_t nRestyled, view::string_view deletedText) {
+void TextArea::bufModifiedCallback(TextCursor pos, int64_t nInserted, int64_t nDeleted, int64_t nRestyled, ext::string_view deletedText) {
 
 	const QRect viewRect = viewport()->contentsRect();
 	int64_t linesInserted;
@@ -1869,7 +1869,7 @@ TextCursor TextArea::startOfLine(TextCursor pos) const {
  * @param linesInserted
  * @param linesDeleted
  */
-void TextArea::findWrapRange(view::string_view deletedText, TextCursor pos, int64_t nInserted, int64_t nDeleted, TextCursor *modRangeStart, TextCursor *modRangeEnd, int64_t *linesInserted, int64_t *linesDeleted) {
+void TextArea::findWrapRange(ext::string_view deletedText, TextCursor pos, int64_t nInserted, int64_t nDeleted, TextCursor *modRangeStart, TextCursor *modRangeEnd, int64_t *linesInserted, int64_t *linesDeleted) {
 
 	TextCursor retPos;
 	TextCursor retLineStart;
@@ -2833,7 +2833,7 @@ void TextArea::redisplayLine(QPainter *painter, int visLineNum, int leftClip, in
 	char *outPtr = buffer;
 	int x        = startX;
 	size_t charIndex;
-	boost::optional<int> cursorX;
+	ext::optional<int> cursorX;
 
 	for (charIndex = startIndex;; ++charIndex) {
 
@@ -2868,7 +2868,7 @@ void TextArea::redisplayLine(QPainter *painter, int visLineNum, int leftClip, in
 
 			if (charStyle != style) {
 
-				drawString(painter, style, startX, y, x, view::string_view(buffer, outPtr - buffer));
+				drawString(painter, style, startX, y, x, ext::string_view(buffer, outPtr - buffer));
 
 				outPtr = buffer;
 				startX = x;
@@ -2890,7 +2890,7 @@ void TextArea::redisplayLine(QPainter *painter, int visLineNum, int leftClip, in
 	}
 
 	// Draw the remaining style segment
-	drawString(painter, style, startX, y, x, view::string_view(buffer, outPtr - buffer));
+	drawString(painter, style, startX, y, x, ext::string_view(buffer, outPtr - buffer));
 
 	/* Draw the cursor if part of it appeared on the redisplayed part of
 	   this line.  Also check for the cases which are not caught as the
@@ -2987,7 +2987,7 @@ uint32_t TextArea::styleOfPos(TextCursor lineStartPos, size_t lineLen, size_t li
 ** rectangle where text would have drawn from x to toX and from y to
 ** the maximum y extent of the current font(s).
 */
-void TextArea::drawString(QPainter *painter, uint32_t style, int x, int y, int toX, view::string_view string) {
+void TextArea::drawString(QPainter *painter, uint32_t style, int x, int y, int toX, ext::string_view string) {
 
 	const QRect viewRect = viewport()->contentsRect();
 	const QPalette &pal  = palette();
@@ -3436,14 +3436,14 @@ void TextArea::updateCalltip(int calltipID) {
 
 	if (calltip_.anchored) {
 		// Put it at the anchor position
-		if (!positionToXY(boost::get<TextCursor>(calltip_.pos), &rel_x, &rel_y)) {
+		if (!positionToXY(ext::get<TextCursor>(calltip_.pos), &rel_x, &rel_y)) {
 			if (calltip_.alignMode == TipAlignMode::Strict) {
 				TextDKillCalltip(calltip_.ID);
 			}
 			return;
 		}
 	} else {
-		if (boost::get<int>(calltip_.pos) < 0) {
+		if (ext::get<int>(calltip_.pos) < 0) {
 			// First display of tip with cursor offscreen (detected in ShowCalltip)
 			calltip_.pos    = viewRect.width() / 2;
 			calltip_.hAlign = TipHAlignMode::Center;
@@ -3455,7 +3455,7 @@ void TextArea::updateCalltip(int calltipID) {
 			}
 			return;
 		}
-		rel_x = boost::get<int>(calltip_.pos);
+		rel_x = ext::get<int>(calltip_.pos);
 	}
 
 	const int lineHeight = fixedFontHeight_;
@@ -4196,7 +4196,7 @@ bool TextArea::checkReadOnly() const {
 ** treated as pending delete selections (true), or ignored (false). "event"
 ** is optional and is just passed on to the cursor movement callbacks.
 */
-void TextArea::TextInsertAtCursor(view::string_view chars, bool allowPendingDelete, bool allowWrap) {
+void TextArea::TextInsertAtCursor(ext::string_view chars, bool allowPendingDelete, bool allowWrap) {
 
 	const QRect viewRect = viewport()->contentsRect();
 	const int fontWidth  = fixedFontWidth_;
@@ -4289,7 +4289,7 @@ bool TextArea::pendingSelection() const {
 ** smart indent (which can be triggered by wrapping) can search back farther
 ** in the buffer than just the text in startLine.
 */
-std::string TextArea::wrapText(view::string_view startLine, view::string_view text, int64_t bufOffset, int wrapMargin, int64_t *breakBefore) {
+std::string TextArea::wrapText(ext::string_view startLine, ext::string_view text, int64_t bufOffset, int wrapMargin, int64_t *breakBefore) {
 
 	// Create a temporary text buffer and load it with the strings
 	TextBuffer wrapBuf;
@@ -4353,7 +4353,7 @@ std::string TextArea::wrapText(view::string_view startLine, view::string_view te
 ** Insert "text" (which must not contain newlines), overstriking the current
 ** cursor location.
 */
-void TextArea::TextDOverstrike(view::string_view text) {
+void TextArea::TextDOverstrike(ext::string_view text) {
 
 	const TextCursor startPos  = cursorPos_;
 	const TextCursor lineStart = buffer_->BufStartOfLine(startPos);
@@ -4416,7 +4416,7 @@ void TextArea::TextDOverstrike(view::string_view text) {
 ** then moving the insert position after the newly inserted text, except
 ** that it's optimized to do less redrawing.
 */
-void TextArea::insertText(view::string_view text) {
+void TextArea::insertText(ext::string_view text) {
 
 	const TextCursor pos = cursorPos_;
 
@@ -4506,7 +4506,7 @@ std::string TextArea::createIndentString(TextBuffer *buf, int64_t bufOffset, Tex
 		smartIndent.reason     = NEWLINE_INDENT_NEEDED;
 		smartIndent.pos        = lineEndPos + bufOffset;
 		smartIndent.request    = 0;
-		smartIndent.charsTyped = view::string_view();
+		smartIndent.charsTyped = ext::string_view();
 
 		for (auto &c : smartIndentCallbacks_) {
 			c.first(this, &smartIndent, c.second);
@@ -4702,10 +4702,10 @@ TextCursor TextArea::startOfWord(TextCursor pos) const {
 
 	const char ch = buffer_->BufGetCharacter(pos);
 
-	boost::optional<TextCursor> startPos;
+	ext::optional<TextCursor> startPos;
 
 	if (ch == ' ' || ch == '\t') {
-		startPos = spanBackward(buffer_, pos, view::string_view(" \t", 2), false);
+		startPos = spanBackward(buffer_, pos, ext::string_view(" \t", 2), false);
 	} else if (isDelimeter(ch)) {
 		startPos = spanBackward(buffer_, pos, delimiters_, true);
 	} else {
@@ -4727,10 +4727,10 @@ TextCursor TextArea::endOfWord(TextCursor pos) const {
 
 	const char ch = buffer_->BufGetCharacter(pos);
 
-	boost::optional<TextCursor> endPos;
+	ext::optional<TextCursor> endPos;
 
 	if (ch == ' ' || ch == '\t') {
-		endPos = spanForward(buffer_, pos, view::string_view(" \t", 2), false);
+		endPos = spanForward(buffer_, pos, ext::string_view(" \t", 2), false);
 	} else if (isDelimeter(ch)) {
 		endPos = spanForward(buffer_, pos, delimiters_, true);
 	} else {
@@ -4749,10 +4749,10 @@ TextCursor TextArea::endOfWord(TextCursor pos) const {
 ** "searchChars",  starting with the character BEFORE "startPos". If
 ** ignoreSpace is set, then Space, Tab, and Newlines are ignored in searchChars.
 */
-boost::optional<TextCursor> TextArea::spanBackward(TextBuffer *buf, TextCursor startPos, view::string_view searchChars, bool ignoreSpace) const {
+ext::optional<TextCursor> TextArea::spanBackward(TextBuffer *buf, TextCursor startPos, ext::string_view searchChars, bool ignoreSpace) const {
 
 	if (startPos == 0) {
-		return boost::none;
+		return {};
 	}
 
 	TextCursor pos = startPos - 1;
@@ -4775,7 +4775,7 @@ boost::optional<TextCursor> TextArea::spanBackward(TextBuffer *buf, TextCursor s
 		--pos;
 	}
 
-	return boost::none;
+	return {};
 }
 
 /*
@@ -4783,7 +4783,7 @@ boost::optional<TextCursor> TextArea::spanBackward(TextBuffer *buf, TextCursor s
 ** "searchChars",  starting with the character "startPos". If ignoreSpace
 ** is set, then Space, Tab, and Newlines are ignored in searchChars.
 */
-boost::optional<TextCursor> TextArea::spanForward(TextBuffer *buf, TextCursor startPos, view::string_view searchChars, bool ignoreSpace) const {
+ext::optional<TextCursor> TextArea::spanForward(TextBuffer *buf, TextCursor startPos, ext::string_view searchChars, bool ignoreSpace) const {
 
 	TextCursor pos = startPos;
 	while (pos < buf->length()) {
@@ -4803,7 +4803,7 @@ boost::optional<TextCursor> TextArea::spanForward(TextBuffer *buf, TextCursor st
 		++pos;
 	}
 
-	return boost::none;
+	return {};
 }
 
 void TextArea::processShiftUpAP(EventFlags flags) {
@@ -4965,7 +4965,7 @@ void TextArea::insertClipboard(bool isColumnar) {
 ** typed.  Same as TextInsertAtCursorEx, but without the complicated auto-wrap
 ** scanning and re-formatting.
 */
-void TextArea::simpleInsertAtCursor(view::string_view chars, bool allowPendingDelete) {
+void TextArea::simpleInsertAtCursor(ext::string_view chars, bool allowPendingDelete) {
 
 	if (allowPendingDelete && pendingSelection()) {
 		buffer_->BufReplaceSelected(chars);
@@ -4973,7 +4973,7 @@ void TextArea::simpleInsertAtCursor(view::string_view chars, bool allowPendingDe
 	} else if (overstrike_) {
 
 		const size_t index = chars.find('\n');
-		if (index != view::string_view::npos) {
+		if (index != ext::string_view::npos) {
 			insertText(chars);
 		} else {
 			TextDOverstrike(chars);
@@ -7157,13 +7157,13 @@ TextCursor TextArea::cursorPos() const {
 ** WORKS FOR DISPLAYED LINES AND, IN CONTINUOUS WRAP MODE, ONLY WHEN THE
 ** ABSOLUTE LINE NUMBER IS BEING MAINTAINED.  Otherwise, it returns false.
 */
-boost::optional<Location> TextArea::positionToLineAndCol(TextCursor pos) const {
+ext::optional<Location> TextArea::positionToLineAndCol(TextCursor pos) const {
 	/* In continuous wrap mode, the absolute (non-wrapped) line count is
 	   maintained separately, as needed.  Only return it if we're actually
 	   keeping track of it and pos is in the displayed text */
 	if (continuousWrap_) {
 		if (!maintainingAbsTopLineNum() || pos < firstChar_ || pos > lastChar_) {
-			return boost::none;
+			return {};
 		}
 
 		Location loc;
@@ -7175,7 +7175,7 @@ boost::optional<Location> TextArea::positionToLineAndCol(TextCursor pos) const {
 	// Only return the data if pos is within the displayed text
 	int visLineNum;
 	if (!posToVisibleLineNum(pos, &visLineNum)) {
-		return boost::none;
+		return {};
 	}
 
 	Location loc;
@@ -7521,7 +7521,7 @@ int TextArea::TextDShowCalltip(const QString &text, bool anchored, CallTipPositi
 	if (anchored) {
 		// Put it at the specified position
 		// If position is not displayed, return 0
-		if (boost::get<TextCursor>(pos) < firstChar_ || boost::get<TextCursor>(pos) > lastChar_) {
+		if (ext::get<TextCursor>(pos) < firstChar_ || ext::get<TextCursor>(pos) > lastChar_) {
 			QApplication::beep();
 			return 0;
 		}
@@ -7632,7 +7632,7 @@ void TextArea::beginningOfSelectionAP(EventFlags flags) {
 
 	EMIT_EVENT_0("beginning_of_selection");
 
-	const boost::optional<SelectionPos> pos = buffer_->BufGetSelectionPos();
+	const ext::optional<SelectionPos> pos = buffer_->BufGetSelectionPos();
 	if (!pos) {
 		return;
 	}
@@ -7706,7 +7706,7 @@ void TextArea::endOfSelectionAP(EventFlags flags) {
 
 	EMIT_EVENT_0("end_of_selection");
 
-	const boost::optional<SelectionPos> pos = buffer_->BufGetSelectionPos();
+	const ext::optional<SelectionPos> pos = buffer_->BufGetSelectionPos();
 	if (!pos) {
 		return;
 	}

--- a/src/TextArea.h
+++ b/src/TextArea.h
@@ -6,11 +6,12 @@
 #include "CallTip.h"
 #include "CursorStyles.h"
 #include "DragStates.h"
+#include "Ext/optional.h"
+#include "Ext/string_view.h"
 #include "Location.h"
 #include "StyleTableEntry.h"
 #include "TextBufferFwd.h"
 #include "TextCursor.h"
-#include "Util/string_view.h"
 
 #include <QAbstractScrollArea>
 #include <QColor>
@@ -23,8 +24,6 @@
 
 #include <memory>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 class CallTipWidget;
 class TextArea;
@@ -204,7 +203,7 @@ public:
 	TextCursor firstVisiblePos() const;
 	TextCursor cursorPos() const;
 	TextCursor TextLastVisiblePos() const;
-	boost::optional<Location> positionToLineAndCol(TextCursor pos) const;
+	ext::optional<Location> positionToLineAndCol(TextCursor pos) const;
 	TextCursor lineAndColToPosition(Location loc) const;
 	TextBuffer *styleBuffer() const;
 	int TextDGetCalltipID(int id) const;
@@ -250,7 +249,7 @@ public:
 
 public:
 	void bufPreDeleteCallback(TextCursor pos, int64_t nDeleted);
-	void bufModifiedCallback(TextCursor pos, int64_t nInserted, int64_t nDeleted, int64_t nRestyled, view::string_view deletedText);
+	void bufModifiedCallback(TextCursor pos, int64_t nInserted, int64_t nDeleted, int64_t nRestyled, ext::string_view deletedText);
 
 private:
 	QColor getRangesetColor(size_t ind, QColor bground) const;
@@ -285,8 +284,8 @@ private:
 	bool visibleLineContainsCursor(int visLine, TextCursor cursor) const;
 	bool wrapLine(TextBuffer *buf, int64_t bufOffset, TextCursor lineStartPos, TextCursor lineEndPos, TextCursor limitPos, TextCursor *breakAt, int64_t *charsAdded);
 	bool wrapUsesCharacter(TextCursor lineEndPos) const;
-	boost::optional<TextCursor> spanBackward(TextBuffer *buf, TextCursor startPos, view::string_view searchChars, bool ignoreSpace) const;
-	boost::optional<TextCursor> spanForward(TextBuffer *buf, TextCursor startPos, view::string_view searchChars, bool ignoreSpace) const;
+	ext::optional<TextCursor> spanBackward(TextBuffer *buf, TextCursor startPos, ext::string_view searchChars, bool ignoreSpace) const;
+	ext::optional<TextCursor> spanForward(TextBuffer *buf, TextCursor startPos, ext::string_view searchChars, bool ignoreSpace) const;
 	int offsetWrappedColumn(int row, int column) const;
 	int offsetWrappedRow(int row) const;
 	int preferredColumn(int *visLineNum, TextCursor *lineStartPos);
@@ -298,7 +297,7 @@ private:
 	int visLineLength(int visLineNum) const;
 	int widthInPixels(char ch, int column) const;
 	std::string createIndentString(TextBuffer *buf, int64_t bufOffset, TextCursor lineStartPos, TextCursor lineEndPos, int *column);
-	std::string wrapText(view::string_view startLine, view::string_view text, int64_t bufOffset, int wrapMargin, int64_t *breakBefore);
+	std::string wrapText(ext::string_view startLine, ext::string_view text, int64_t bufOffset, int wrapMargin, int64_t *breakBefore);
 	uint32_t styleOfPos(TextCursor lineStartPos, size_t lineLen, size_t lineIndex, int64_t dispIndex, int thisChar) const;
 	void beginBlockDrag();
 	void blockDragSelection(const QPoint &pos, BlockDragTypes dragType);
@@ -311,10 +310,10 @@ private:
 	void TextCutClipboard();
 	void TextDBlankCursor();
 	void TextDMakeInsertPosVisible();
-	void TextDOverstrike(view::string_view text);
+	void TextDOverstrike(ext::string_view text);
 	void setWrapMode(bool wrap, int wrapMargin);
 	void coordToUnconstrainedPosition(const QPoint &coord, int *row, int *column) const;
-	void TextInsertAtCursor(view::string_view chars, bool allowPendingDelete, bool allowWrap);
+	void TextInsertAtCursor(ext::string_view chars, bool allowPendingDelete, bool allowWrap);
 	void TextPasteClipboard();
 	void adjustSecondarySelection(const QPoint &coord);
 	void adjustSelection(const QPoint &coord);
@@ -328,15 +327,15 @@ private:
 	void checkAutoShowInsertPos();
 	void checkMoveSelectionChange(EventFlags flags, TextCursor startPos);
 	void drawCursor(QPainter *painter, int x, int y);
-	void drawString(QPainter *painter, uint32_t style, int x, int y, int toX, view::string_view string);
+	void drawString(QPainter *painter, uint32_t style, int x, int y, int toX, ext::string_view string);
 	void endDrag();
 	void extendRangeForStyleMods(TextCursor *start, TextCursor *end);
 	void findLineEnd(TextCursor startPos, bool startPosIsLineStart, TextCursor *lineEnd, TextCursor *nextLineStart);
-	void findWrapRange(view::string_view deletedText, TextCursor pos, int64_t nInserted, int64_t nDeleted, TextCursor *modRangeStart, TextCursor *modRangeEnd, int64_t *linesInserted, int64_t *linesDeleted);
+	void findWrapRange(ext::string_view deletedText, TextCursor pos, int64_t nInserted, int64_t nDeleted, TextCursor *modRangeStart, TextCursor *modRangeEnd, int64_t *linesInserted, int64_t *linesDeleted);
 	void handleResize(bool widthChanged);
 	void hideOrShowHScrollBar();
 	void insertClipboard(bool isColumnar);
-	void insertText(view::string_view text);
+	void insertText(ext::string_view text);
 	void keyMoveExtendSelection(TextCursor origPos, bool rectangular);
 	void measureDeletedLines(TextCursor pos, int64_t nDeleted);
 	void offsetAbsLineNum(TextCursor oldFirstChar);
@@ -354,7 +353,7 @@ private:
 	void setLineNumberAreaWidth(int lineNumWidth);
 	void setupBGClasses(const QString &str);
 	void showResizeNotification();
-	void simpleInsertAtCursor(view::string_view chars, bool allowPendingDelete);
+	void simpleInsertAtCursor(ext::string_view chars, bool allowPendingDelete);
 	void unblankCursor();
 	void updateCalltip(int calltipID);
 	void updateFontMetrics(const QFont &font);

--- a/src/TextBuffer.h
+++ b/src/TextBuffer.h
@@ -2,10 +2,10 @@
 #ifndef TEXT_BUFFER_H_
 #define TEXT_BUFFER_H_
 
+#include "Ext/string_view.h"
 #include "TextBufferFwd.h"
 #include "TextCursor.h"
 #include "TextRange.h"
-#include "Util/string_view.h"
 #include "gap_buffer.h"
 
 #include <gsl/gsl_util>
@@ -15,7 +15,7 @@
 #include <memory>
 #include <string>
 
-#include <boost/optional.hpp>
+#include "Ext/optional.h"
 
 struct SelectionPos {
 	TextCursor start;
@@ -29,7 +29,7 @@ template <class Ch, class Tr>
 class BasicTextBuffer : public std::enable_shared_from_this<BasicTextBuffer<Ch, Tr>> {
 public:
 	using string_type = std::basic_string<Ch, Tr>;
-	using view_type   = view::basic_string_view<Ch, Tr>;
+	using view_type   = ext::basic_string_view<Ch, Tr>;
 
 public:
 	using modify_callback_type     = void (*)(TextCursor pos, int64_t nInserted, int64_t nDeleted, int64_t nRestyled, view_type deletedText, void *user);
@@ -55,7 +55,7 @@ public:
 		friend class BasicTextBuffer;
 
 	public:
-		boost::optional<SelectionPos> getSelectionPos() const;
+		ext::optional<SelectionPos> getSelectionPos() const;
 		bool getSelectionPos(TextCursor *start, TextCursor *end, bool *isRect, int64_t *rectStart, int64_t *rectEnd) const;
 		bool inSelection(TextCursor pos, TextCursor lineStartPos, int64_t dispIndex) const;
 		bool rangeTouchesRectSel(TextCursor rangeStart, TextCursor rangeEnd) const;
@@ -101,13 +101,13 @@ public:
 public:
 	bool BufGetEmptySelectionPos(TextCursor *start, TextCursor *end, bool *isRect, int64_t *rectStart, int64_t *rectEnd) const noexcept;
 	bool BufGetSelectionPos(TextCursor *start, TextCursor *end, bool *isRect, int64_t *rectStart, int64_t *rectEnd) const noexcept;
-	boost::optional<SelectionPos> BufGetSelectionPos() const noexcept;
+	ext::optional<SelectionPos> BufGetSelectionPos() const noexcept;
 	bool BufGetSyncXSelection() const;
 	bool BufGetUseTabs() const noexcept;
 	bool BufIsEmpty() const noexcept;
 	bool BufSetSyncXSelection(bool sync);
-	boost::optional<TextCursor> searchBackward(TextCursor startPos, view_type searchChars) const noexcept;
-	boost::optional<TextCursor> searchForward(TextCursor startPos, view_type searchChars) const noexcept;
+	ext::optional<TextCursor> searchBackward(TextCursor startPos, view_type searchChars) const noexcept;
+	ext::optional<TextCursor> searchForward(TextCursor startPos, view_type searchChars) const noexcept;
 	Ch BufGetCharacter(TextCursor pos) const noexcept;
 	int64_t BufCountDispChars(TextCursor lineStartPos, TextCursor targetPos) const noexcept;
 	int64_t BufCountLines(TextCursor startPos, TextCursor endPos) const noexcept;
@@ -176,8 +176,8 @@ public:
 	bool GetSimpleSelection(TextRange *range) const noexcept;
 
 private:
-	boost::optional<TextCursor> searchBackward(TextCursor startPos, Ch searchChar) const noexcept;
-	boost::optional<TextCursor> searchForward(TextCursor startPos, Ch searchChar) const noexcept;
+	ext::optional<TextCursor> searchBackward(TextCursor startPos, Ch searchChar) const noexcept;
+	ext::optional<TextCursor> searchForward(TextCursor startPos, Ch searchChar) const noexcept;
 	int64_t insert(TextCursor pos, view_type text) noexcept;
 	int64_t insert(TextCursor pos, Ch ch) noexcept;
 	string_type getSelectionText(const Selection *sel) const;

--- a/src/TextBuffer.tcc
+++ b/src/TextBuffer.tcc
@@ -620,7 +620,7 @@ void BasicTextBuffer<Ch, Tr>::BufRectSelect(TextCursor start, TextCursor end, in
 }
 
 template <class Ch, class Tr>
-boost::optional<SelectionPos> BasicTextBuffer<Ch, Tr>::BufGetSelectionPos() const noexcept {
+ext::optional<SelectionPos> BasicTextBuffer<Ch, Tr>::BufGetSelectionPos() const noexcept {
 	return primary.getSelectionPos();
 }
 
@@ -786,7 +786,7 @@ TextCursor BasicTextBuffer<Ch, Tr>::BufEndOfBuffer() const noexcept {
 template <class Ch, class Tr>
 TextCursor BasicTextBuffer<Ch, Tr>::BufStartOfLine(TextCursor pos) const noexcept {
 
-	boost::optional<TextCursor> startPos = searchBackward(pos, Ch('\n'));
+	ext::optional<TextCursor> startPos = searchBackward(pos, Ch('\n'));
 	if (!startPos) {
 		return {};
 	}
@@ -802,7 +802,7 @@ TextCursor BasicTextBuffer<Ch, Tr>::BufStartOfLine(TextCursor pos) const noexcep
 template <class Ch, class Tr>
 TextCursor BasicTextBuffer<Ch, Tr>::BufEndOfLine(TextCursor pos) const noexcept {
 
-	boost::optional<TextCursor> endPos = searchForward(pos, Ch('\n'));
+	ext::optional<TextCursor> endPos = searchForward(pos, Ch('\n'));
 	if (!endPos) {
 		return BufEndOfBuffer();
 	}
@@ -1026,7 +1026,7 @@ TextCursor BasicTextBuffer<Ch, Tr>::BufCountBackwardNLines(TextCursor startPos, 
 ** with the character at "startPos", and returning the result
 */
 template <class Ch, class Tr>
-boost::optional<TextCursor> BasicTextBuffer<Ch, Tr>::searchForward(TextCursor startPos, view_type searchChars) const noexcept {
+ext::optional<TextCursor> BasicTextBuffer<Ch, Tr>::searchForward(TextCursor startPos, view_type searchChars) const noexcept {
 
 	TextCursor pos = startPos;
 	TextCursor end = BufEndOfBuffer();
@@ -1044,7 +1044,7 @@ boost::optional<TextCursor> BasicTextBuffer<Ch, Tr>::searchForward(TextCursor st
 		++pos;
 	}
 
-	return boost::none;
+	return {};
 }
 
 /*
@@ -1052,12 +1052,12 @@ boost::optional<TextCursor> BasicTextBuffer<Ch, Tr>::searchForward(TextCursor st
 ** with the character BEFORE at "startPos"
 */
 template <class Ch, class Tr>
-boost::optional<TextCursor> BasicTextBuffer<Ch, Tr>::searchBackward(TextCursor startPos, view_type searchChars) const noexcept {
+ext::optional<TextCursor> BasicTextBuffer<Ch, Tr>::searchBackward(TextCursor startPos, view_type searchChars) const noexcept {
 
 	const TextCursor start = BufStartOfBuffer();
 
 	if (startPos == start) {
-		return boost::none;
+		return {};
 	}
 
 	TextCursor pos = startPos - 1;
@@ -1079,7 +1079,7 @@ boost::optional<TextCursor> BasicTextBuffer<Ch, Tr>::searchBackward(TextCursor s
 		--pos;
 	}
 
-	return boost::none;
+	return {};
 }
 
 /*
@@ -1140,7 +1140,7 @@ int64_t BasicTextBuffer<Ch, Tr>::insert(TextCursor pos, Ch ch) noexcept {
 ** count lines quickly, hence searching for a single character: newline)
 */
 template <class Ch, class Tr>
-boost::optional<TextCursor> BasicTextBuffer<Ch, Tr>::searchForward(TextCursor startPos, Ch searchChar) const noexcept {
+ext::optional<TextCursor> BasicTextBuffer<Ch, Tr>::searchForward(TextCursor startPos, Ch searchChar) const noexcept {
 
 	TextCursor pos = startPos;
 	TextCursor end = BufEndOfBuffer();
@@ -1152,7 +1152,7 @@ boost::optional<TextCursor> BasicTextBuffer<Ch, Tr>::searchForward(TextCursor st
 		++pos;
 	}
 
-	return boost::none;
+	return {};
 }
 
 /*
@@ -1163,12 +1163,12 @@ boost::optional<TextCursor> BasicTextBuffer<Ch, Tr>::searchForward(TextCursor st
 ** count lines quickly, hence searching for a single character: newline)
 */
 template <class Ch, class Tr>
-boost::optional<TextCursor> BasicTextBuffer<Ch, Tr>::searchBackward(TextCursor startPos, Ch searchChar) const noexcept {
+ext::optional<TextCursor> BasicTextBuffer<Ch, Tr>::searchBackward(TextCursor startPos, Ch searchChar) const noexcept {
 
 	TextCursor start = BufStartOfBuffer();
 
 	if (startPos == start) {
-		return boost::none;
+		return {};
 	}
 
 	TextCursor pos = startPos - 1;
@@ -1178,7 +1178,7 @@ boost::optional<TextCursor> BasicTextBuffer<Ch, Tr>::searchBackward(TextCursor s
 		}
 
 		if (pos == start) {
-			return boost::none;
+			return {};
 		}
 
 		--pos;
@@ -2181,9 +2181,9 @@ bool BasicTextBuffer<Ch, Tr>::Selection::getSelectionPos(TextCursor *start, Text
 }
 
 template <class Ch, class Tr>
-boost::optional<SelectionPos> BasicTextBuffer<Ch, Tr>::Selection::getSelectionPos() const {
+ext::optional<SelectionPos> BasicTextBuffer<Ch, Tr>::Selection::getSelectionPos() const {
 	if (!selected_) {
-		return boost::none;
+		return {};
 	}
 
 	SelectionPos pos = {};

--- a/src/gap_buffer.h
+++ b/src/gap_buffer.h
@@ -2,7 +2,8 @@
 #ifndef GAP_BUFFER_H_
 #define GAP_BUFFER_H_
 
-#include "Util/string_view.h"
+#include "Ext/string_view.h"
+#include "Util/Raise.h"
 #include "gap_buffer_fwd.h"
 #include "gap_buffer_iterator.h"
 
@@ -16,7 +17,7 @@ class gap_buffer {
 public:
 	static constexpr int PreferredGapSize = 80;
 	using string_type                     = std::basic_string<Ch, Tr>;
-	using view_type                       = view::basic_string_view<Ch, Tr>;
+	using view_type                       = ext::basic_string_view<Ch, Tr>;
 
 public:
 	using value_type             = typename std::allocator<Ch>::value_type;

--- a/src/shift.cpp
+++ b/src/shift.cpp
@@ -1,10 +1,10 @@
 
 #include "shift.h"
 #include "DocumentWidget.h"
+#include "Ext/string_view.h"
 #include "TextArea.h"
 #include "TextBuffer.h"
 #include "Util/algorithm.h"
-#include "Util/string_view.h"
 
 #include <gsl/gsl_util>
 
@@ -40,7 +40,7 @@ std::string makeIndentString(int64_t indent, int tabDist, bool allowTabs) {
 ** re-creating whitespace to the left of the text using tabs (if allowTabs is
 ** true) calculated using tabDist, and spaces.
 */
-std::string fillParagraph(view::string_view text, int64_t leftMargin, int64_t firstLineIndent, int64_t rightMargin, int tabDist, bool allowTabs) {
+std::string fillParagraph(ext::string_view text, int64_t leftMargin, int64_t firstLineIndent, int64_t rightMargin, int tabDist, bool allowTabs) {
 
 	size_t nLines = 1;
 
@@ -212,7 +212,7 @@ int findLeftMargin(In first, In last, Size length, int tabDist) {
 ** capability not currently used in NEdit, but carried over from code for
 ** previous versions which did all paragraphs together).
 */
-std::string fillParagraphs(view::string_view text, int64_t rightMargin, int tabDist, int useTabs, bool alignWithFirst) {
+std::string fillParagraphs(ext::string_view text, int64_t rightMargin, int tabDist, int useTabs, bool alignWithFirst) {
 
 	// Create a buffer to accumulate the filled paragraphs
 	TextBuffer buf;
@@ -304,7 +304,7 @@ TextCursor findParagraphStart(TextBuffer *buf, TextCursor startPos) {
 	return parStart > buf->BufStartOfBuffer() ? parStart : buf->BufStartOfBuffer();
 }
 
-int countLines(view::string_view text) {
+int countLines(ext::string_view text) {
 	return std::count(text.begin(), text.end(), '\n') + 1;
 }
 
@@ -376,7 +376,7 @@ QString shiftLineLeft(const QString &line, int64_t lineLen, int tabDist, int nCh
 	}
 }
 
-std::string shiftLineLeft(view::string_view line, int64_t lineLen, int tabDist, int nChars) {
+std::string shiftLineLeft(ext::string_view line, int64_t lineLen, int tabDist, int nChars) {
 
 	auto lineInPtr = line.begin();
 
@@ -480,7 +480,7 @@ QString shiftLineRight(const QString &line, int64_t lineLen, int tabsAllowed, in
 	}
 }
 
-std::string shiftLineRight(view::string_view line, int64_t lineLen, int tabsAllowed, int tabDist, int nChars) {
+std::string shiftLineRight(ext::string_view line, int64_t lineLen, int tabsAllowed, int tabDist, int nChars) {
 	int whiteWidth;
 
 	auto lineInPtr = line.begin();
@@ -526,7 +526,7 @@ std::string shiftLineRight(view::string_view line, int64_t lineLen, int tabsAllo
 	}
 }
 
-std::string shiftText(view::string_view text, ShiftDirection direction, int tabsAllowed, int tabDist, int nChars) {
+std::string shiftText(ext::string_view text, ShiftDirection direction, int tabsAllowed, int tabDist, int nChars) {
 	size_t bufLen;
 
 	/*

--- a/src/userCmds.cpp
+++ b/src/userCmds.cpp
@@ -13,7 +13,7 @@
 #include <QFileInfo>
 #include <QTextStream>
 
-#include <boost/optional.hpp>
+#include "Ext/optional.h"
 #include <memory>
 #include <yaml-cpp/yaml.h>
 
@@ -269,7 +269,7 @@ QString writeContextMenuYaml(const std::vector<MenuData> &menuItems) {
  * @param in
  * @param listType
  */
-boost::optional<MenuItem> readMenuItem(Input &in, CommandTypes listType) {
+ext::optional<MenuItem> readMenuItem(Input &in, CommandTypes listType) {
 
 	struct ParseError {
 		std::string message;
@@ -370,7 +370,7 @@ boost::optional<MenuItem> readMenuItem(Input &in, CommandTypes listType) {
 
 			QString p = copyMacroToEnd(in);
 			if (p.isNull()) {
-				return boost::none;
+				return {};
 			}
 
 			cmdStr = p;
@@ -392,7 +392,7 @@ boost::optional<MenuItem> readMenuItem(Input &in, CommandTypes listType) {
 		return menuItem;
 	} catch (const ParseError &error) {
 		qWarning("NEdit: Parse error in user defined menu item, %s", error.message.c_str());
-		return boost::none;
+		return {};
 	}
 }
 
@@ -617,7 +617,7 @@ void loadMenuItemString(const QString &inString, std::vector<MenuData> &menuItem
 				return;
 			}
 
-			boost::optional<MenuItem> f = readMenuItem(in, listType);
+			ext::optional<MenuItem> f = readMenuItem(in, listType);
 			if (!f) {
 				break;
 			}


### PR DESCRIPTION
Working on making boost not required if we happen to have a C++17 compiler

Abstracts all boost usage to a new `Ext` library that will be std if we have C++17, or boost otherwise.