### PR TITLE
reworking code that takes data from sub-processes so that it avoids using a QString as much as possible.

### DIFF
--- a/src/macro.cpp
+++ b/src/macro.cpp
@@ -5212,7 +5212,7 @@ void RegisterMacroSubroutines() {
 ** teaching other modules about macro return globals, since other than this,
 ** they're not used outside of macro.c)
 */
-void returnShellCommandOutput(DocumentWidget *document, const QString &outText, int status) {
+void returnShellCommandOutput(DocumentWidget *document, view::string_view outText, int status) {
 
 	if (const std::shared_ptr<MacroCommandData> cmdData = document->macroCmdData_) {
 

--- a/src/macro.h
+++ b/src/macro.h
@@ -4,6 +4,7 @@
 
 #include <QTimer>
 #include <memory>
+#include "Util/string_view.h"
 
 class DocumentWidget;
 class MainWindow;
@@ -22,7 +23,7 @@ bool CheckMacroString(QWidget *dialogParent, const QString &string, const QStrin
 bool readCheckMacroString(QWidget *dialogParent, const QString &string, DocumentWidget *runDocument, const QString &errIn, int *errPos);
 
 void RegisterMacroSubroutines();
-void returnShellCommandOutput(DocumentWidget *document, const QString &outText, int status);
+void returnShellCommandOutput(DocumentWidget *document, view::string_view outText, int status);
 
 /* Data attached to window during shell command execution with
    information for controlling and communicating with the process */


### PR DESCRIPTION
reworking code that takes data from sub-processes so that it avoids using a QString as much as possible.
this is necessary because, at least in Qt5, there is a hard upper limit to the length of a QString
addesses issue #354