### PR TITLE
Only track a single mouse button at a time

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,9 +8,9 @@ on:
 
 env:
   BUILD_TYPE: Release
-  BOOST_URL: 'https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.gz'
-  BOOST_TGZ: 'boost_1_78_0.tar.gz'
-  BOOST_PATH: 'D:/boost_1_78_0'
+  BOOST_URL: 'https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_87_0.tar.gz'
+  BOOST_TGZ: 'boost_1_87_0.tar.gz'
+  BOOST_PATH: 'D:/boost_1_87_0'
 
 jobs:
   build_ubuntu_20:

--- a/Regex/Compile.cpp
+++ b/Regex/Compile.cpp
@@ -12,7 +12,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cctype>
 #include <cstring>
 #include <limits>
 #include <gsl/gsl_util>

--- a/Regex/Execute.cpp
+++ b/Regex/Execute.cpp
@@ -10,10 +10,7 @@
 #include "Util/utils.h"
 
 #include <algorithm>
-#include <cassert>
-#include <cctype>
 #include <climits>
-#include <cstdio>
 #include <cstring>
 #include <limits>
 

--- a/Util/String.cpp
+++ b/Util/String.cpp
@@ -2,7 +2,6 @@
 #include "Util/String.h"
 #include "Util/utils.h"
 #include <QString>
-#include <cctype>
 
 /*
 ** If "string" is not terminated with a newline character, return a

--- a/src/DocumentWidget.cpp
+++ b/src/DocumentWidget.cpp
@@ -719,6 +719,8 @@ TextArea *DocumentWidget::createTextArea(const std::shared_ptr<TextBuffer> &buff
 	// policy here, in fact, that would break things.
 	// area->setContextMenuPolicy(Qt::CustomContextMenu);
 
+	area->setContextMenuPolicy(Qt::PreventContextMenu);
+
 	// just emit an event that will later be caught by the higher layer informing it of the context menu request
 	connect(area, &TextArea::customContextMenuRequested, this, [this](const QPoint &pos) {
 		Q_EMIT contextMenuRequested(this, pos);

--- a/src/DocumentWidget.cpp
+++ b/src/DocumentWidget.cpp
@@ -11,7 +11,6 @@
 #include "Font.h"
 #include "Highlight.h"
 #include "HighlightData.h"
-#include "HighlightStyle.h"
 #include "MainWindow.h"
 #include "PatternSet.h"
 #include "Preferences.h"

--- a/src/Highlight.cpp
+++ b/src/Highlight.cpp
@@ -9,7 +9,6 @@
 #include "Regex.h"
 #include "ReparseContext.h"
 #include "Settings.h"
-#include "StyleTableEntry.h"
 #include "TextBuffer.h"
 #include "Util/Input.h"
 #include "Util/Resource.h"
@@ -28,8 +27,6 @@
 
 #include <algorithm>
 #include <climits>
-#include <cmath>
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <memory>

--- a/src/Highlight.cpp
+++ b/src/Highlight.cpp
@@ -1024,8 +1024,8 @@ HighlightData *find_subpattern(const HighlightData *pattern, size_t index) {
  * @return
  */
 std::vector<PatternSet> readDefaultPatternSets() {
-	QByteArray defaultPatternSets = loadResource(QLatin1String("DefaultPatternSets.yaml"));
-	YAML::Node patternSets        = YAML::Load(defaultPatternSets.data());
+	static QByteArray defaultPatternSets = loadResource(QLatin1String("DefaultPatternSets.yaml"));
+	static YAML::Node patternSets        = YAML::Load(defaultPatternSets.data());
 
 	std::vector<PatternSet> defaultPatterns;
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -26,7 +26,6 @@
 #include "Highlight.h"
 #include "LanguageMode.h"
 #include "Location.h"
-#include "PatternSet.h"
 #include "Preferences.h"
 #include "Regex.h"
 #include "Search.h"

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -7,7 +7,6 @@
 #include "MainWindow.h"
 #include "Settings.h"
 #include "SmartIndent.h"
-#include "Tags.h"
 #include "TextBuffer.h"
 #include "Theme.h"
 #include "Util/ClearCase.h"
@@ -29,10 +28,6 @@
 #include <QString>
 #include <QtDebug>
 
-#include <cctype>
-#include <fstream>
-#include <iostream>
-#include <memory>
 
 namespace Preferences {
 namespace {

--- a/src/Rangeset.cpp
+++ b/src/Rangeset.cpp
@@ -2,8 +2,6 @@
 #include "Rangeset.h"
 #include "TextBuffer.h"
 #include <algorithm>
-#include <cctype>
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 

--- a/src/RangesetTable.cpp
+++ b/src/RangesetTable.cpp
@@ -1,9 +1,10 @@
 
 #include "RangesetTable.h"
 #include "TextBuffer.h"
+#include <algorithm>
 #include <array>
 #include <gsl/gsl_util>
-#include <string>
+#include <iterator>
 
 namespace {
 

--- a/src/RangesetTable.h
+++ b/src/RangesetTable.h
@@ -4,6 +4,8 @@
 
 #include "Rangeset.h"
 #include "TextCursor.h"
+#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 class RangesetTable {

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -6,18 +6,14 @@
 #include "Preferences.h"
 #include "Regex.h"
 #include "TextBuffer.h"
-#include "TruncSubstitution.h"
 #include "Util/String.h"
 #include "Util/algorithm.h"
 #include "Util/utils.h"
-#include "WrapStyle.h"
 #include "userCmds.h"
 
 #include <gsl/gsl_util>
 
 #include <algorithm>
-#include <cctype>
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 

--- a/src/SmartIndent.cpp
+++ b/src/SmartIndent.cpp
@@ -18,7 +18,6 @@
 #include <QPointer>
 #include <QtDebug>
 #include <climits>
-#include <cstdio>
 #include <cstring>
 
 namespace SmartIndent {

--- a/src/Tags.cpp
+++ b/src/Tags.cpp
@@ -21,17 +21,11 @@
 #include <QRegularExpression>
 #include <QTextStream>
 
-#include <array>
-#include <cctype>
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <deque>
 #include <fstream>
 #include <iostream>
-#include <memory>
-#include <sstream>
-#include <unordered_map>
 
 #ifdef Q_OS_UNIX
 #include <sys/param.h>

--- a/src/TextArea.cpp
+++ b/src/TextArea.cpp
@@ -1070,11 +1070,7 @@ void TextArea::focusInEvent(QFocusEvent *event) {
 	}
 
 	// Change the cursor to active style
-	if (overstrike_) {
-		setCursorStyle(CursorStyles::Block);
-	} else {
-		setCursorStyle(CursorStyles::Normal);
-	}
+	setCursorStyle(overstrike_ ? CursorStyles::Block : CursorStyles::Normal);
 
 	unblankCursor();
 	QAbstractScrollArea::focusInEvent(event);
@@ -1094,21 +1090,6 @@ void TextArea::focusOutEvent(QFocusEvent *event) {
 	// If there's a calltip displayed, kill it.
 	TextDKillCalltip(0);
 	QAbstractScrollArea::focusOutEvent(event);
-}
-
-/**
- * @brief TextArea::contextMenuEvent
- * @param event
- */
-void TextArea::contextMenuEvent(QContextMenuEvent *event) {
-
-    if (mouseButtonState_ != Qt::MouseButton::NoButton) {
-        return;
-    }
-
-	if (event->modifiers() != Qt::ControlModifier) {
-		Q_EMIT customContextMenuRequested(mapToGlobal(event->pos()));
-	}
 }
 
 /**
@@ -1190,9 +1171,9 @@ void TextArea::keyPressEvent(QKeyEvent *event) {
 void TextArea::mouseDoubleClickEvent(QMouseEvent *event) {
 	if (event->button() == Qt::LeftButton) {
 
-        if (mouseButtonState_ != Qt::MouseButton::NoButton) {
-            return;
-        }
+		if (mouseButtonState_ != Qt::MouseButton::NoButton) {
+			return;
+		}
 
 		if (!clickTracker(event, /*inDoubleClickHandler=*/true)) {
 			return;
@@ -1270,13 +1251,12 @@ void TextArea::mouseMoveEvent(QMouseEvent *event) {
  */
 void TextArea::mousePressEvent(QMouseEvent *event) {
 
-    // only accept one mouse button press at a time
-    if (mouseButtonState_ != Qt::MouseButton::NoButton) {
-        return;
-    }
+	// only accept one mouse button press at a time
+	if (mouseButtonState_ != Qt::MouseButton::NoButton) {
+		return;
+	}
 
-    mouseButtonState_ = event->button();
-
+	mouseButtonState_ = event->button();
 
 	if (event->button() == Qt::LeftButton) {
 		switch (event->modifiers() & (Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier)) {
@@ -1340,22 +1320,25 @@ void TextArea::mousePressEvent(QMouseEvent *event) {
  */
 void TextArea::mouseReleaseEvent(QMouseEvent *event) {
 
-    // ignore key ups from buttons not currently known to be pressed
-    if(mouseButtonState_ != event->button()) {
-        return;
-    }
+	// ignore key ups from buttons not currently known to be pressed
+	if (mouseButtonState_ != event->button()) {
+		return;
+	}
 
-    mouseButtonState_ = Qt::MouseButton::NoButton;
+	mouseButtonState_ = Qt::MouseButton::NoButton;
 
 	switch (event->button()) {
 	case Qt::LeftButton:
-        if(dragState_ == PRIMARY_CLICKED) {
-            endDrag();
-        }
+		if (dragState_ == PRIMARY_CLICKED) {
+			endDrag();
+		}
 		break;
 
 	case Qt::RightButton:
 		endDrag();
+		if (event->modifiers() != Qt::ControlModifier) {
+			Q_EMIT customContextMenuRequested(mapToGlobal(event->pos()));
+		}
 		break;
 
 	case Qt::MiddleButton:

--- a/src/TextArea.cpp
+++ b/src/TextArea.cpp
@@ -1306,6 +1306,9 @@ void TextArea::mousePressEvent(QMouseEvent *event) {
 	} else if (event->button() == Qt::RightButton) {
 		if (event->modifiers() == Qt::ControlModifier) {
 			mousePanAP(event);
+		} else {
+			mouseButtonState_ = Qt::MouseButton::NoButton;
+			Q_EMIT customContextMenuRequested(mapToGlobal(event->pos()));
 		}
 	} else if (event->button() == Qt::MiddleButton) {
 		secondaryOrDragStartAP(event);
@@ -1336,9 +1339,6 @@ void TextArea::mouseReleaseEvent(QMouseEvent *event) {
 
 	case Qt::RightButton:
 		endDrag();
-		if (event->modifiers() != Qt::ControlModifier) {
-			Q_EMIT customContextMenuRequested(mapToGlobal(event->pos()));
-		}
 		break;
 
 	case Qt::MiddleButton:

--- a/src/TextArea.cpp
+++ b/src/TextArea.cpp
@@ -7,7 +7,6 @@
 #include "DragStates.h"
 #include "Font.h"
 #include "Highlight.h"
-#include "LanguageMode.h"
 #include "LineNumberArea.h"
 #include "Preferences.h"
 #include "RangesetTable.h"

--- a/src/TextArea.h
+++ b/src/TextArea.h
@@ -106,7 +106,6 @@ protected:
 	bool focusNextPrevChild(bool next) override;
 	void mouseQuadrupleClickEvent(QMouseEvent *event);
 	void mouseTripleClickEvent(QMouseEvent *event);
-	void contextMenuEvent(QContextMenuEvent *event) override;
 	void focusInEvent(QFocusEvent *event) override;
 	void focusOutEvent(QFocusEvent *event) override;
 	void keyPressEvent(QKeyEvent *event) override;

--- a/src/TextArea.h
+++ b/src/TextArea.h
@@ -437,6 +437,7 @@ private:
 	int64_t rectAnchor_                            = 0; // Anchor for rectangular drag operations
 	int wrapMargin_                                = 0;
 	void *highlightCBArg_                          = nullptr; // Arg to unfinishedHighlightCB
+	Qt::MouseButton mouseButtonState_              = Qt::MouseButton::NoButton;
 
 private:
 	BlockDragTypes dragType_; // style of block drag operation

--- a/src/macro.cpp
+++ b/src/macro.cpp
@@ -13,7 +13,6 @@
 #include "RangesetTable.h"
 #include "Search.h"
 #include "SearchType.h"
-#include "SignalBlocker.h"
 #include "SmartIndent.h"
 #include "TextArea.h"
 #include "TextBuffer.h"


### PR DESCRIPTION
Making it so mouse interaction only tracks one mouse button at a time. 
This prevents corruption of the "state machine" that tracks the drag state.
So if you the user is dragging with a middle mouse button, then right and left clicks are ignored. 
Fixes (long standing) issue #192 ... I hope!