### PR TITLE
FIX: Add <limits> to Execute.h

### DIFF
--- a/Regex/Execute.h
+++ b/Regex/Execute.h
@@ -8,6 +8,7 @@
 #include <bitset>
 #include <cstdint>
 #include <memory>
+#include <limits>
 
 // #define ENABLE_CROSS_REGEX_BACKREF
 


### PR DESCRIPTION
Fixes the error of 
```
nedit-ng/Regex/Execute.cpp:137:62: error: ‘numeric_limits’ is not a member of ‘std’
  137 |         const uint32_t max_cmp      = (max > 0) ? max : std::numeric_limits<uint32_t>::max();
      |                                                              ^~~~~~~~~~~~~~
```